### PR TITLE
Initial commit of minio k8s manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !LICENSE
 
 # And filetypes
+!*.sh
 !*.yml
 !*.yaml
 !*.json

--- a/dstk-infra/README.md
+++ b/dstk-infra/README.md
@@ -1,0 +1,18 @@
+## Prerequisites
+
+- Docker or Podman
+- Minikube
+- kubectl
+- Skaffold
+
+# Usage
+
+```bash
+minikube start
+skaffold dev -p dstk-dev
+```
+
+Optionally you can monitor K8s resources with
+```bash
+minikube dashboard --profile dstk
+```

--- a/dstk-infra/bootstrap.sh
+++ b/dstk-infra/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Convenience functions
+info () {
+  printf "\r[ \033[00;34m..\033[0m ] $1\n"
+}
+
+success () {
+  printf "\r\033[2K[ \033[00;32mOK\033[0m ] $1\n"
+}
+
+fail () {
+  printf "\r\033[2K[\033[0;31mFAIL\033[0m] $1\n"
+}
+
+check_binary () {
+  which $1 > /dev/null 2>&1
+  status=$?
+  if [ $status -eq 0 ]; then
+    success "Found binary ${1} in PATH"
+  else
+    fail "No valid binary for ${1} found in PATH. Please correct your installation"
+    exit 1
+  fi
+}
+
+
+# Setup checks
+set +e
+
+info "Checking for Docker installation..."
+check_binary "docker"
+
+info "Checking for minikube installation..."
+check_binary "minikube"
+
+info "Checking for kubectl installation"
+check_binary "kubectl"
+
+info "Checking for skaffold installation"
+check_binary "skaffold"
+
+set -e
+
+# Minikube startup
+minikube dev --profile dstk-dev

--- a/dstk-infra/src/minio/minio.k8s.yml
+++ b/dstk-infra/src/minio/minio.k8s.yml
@@ -1,0 +1,94 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: minio
+    app.kubernetes.io/name: minio
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.service: minio
+        app.kubernetes.io/name: minio
+    spec:
+      # initContainers:
+      # - name: install
+      #   image: alpine:latest
+      #   command:
+      #   - mkdir
+      #   - -p
+      #   - /data/dstk-registry
+      #   volumeMounts:
+      #   - name:  minio
+      #     mountPath: "/data"
+      containers:
+        - args:
+            - server
+            - /data
+          env:
+            - name: MINIO_ROOT_USER
+              value: ACCESSKEY
+            - name: MINIO_ROOT_PASSWORD
+              value: SECRETKEY
+          image: minio/minio:latest
+          name: minio
+          ports:
+            - containerPort: 9000
+              name: minio-web
+          # volumeMounts:
+          #   - mountPath: /data
+          #     name: minio
+          resources:
+            limits:
+              cpu: 750m
+              memory: 1024Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+
+      restartPolicy: Always
+      # volumes:
+      #   - name: minio
+      #     persistentVolumeClaim:
+      #       claimName: minio
+---
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   labels:
+#     io.kompose.service: minio
+#     app.kubernetes.io/name: minio
+#   name: minio
+# spec:
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 2Gi
+# status: {}
+# ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: minio
+  name: minio
+spec:
+  type: NodePort
+  ports:
+    - name: "9000"
+      port: 9000
+      protocol: TCP
+      targetPort: minio-web
+  selector:
+    io.kompose.service: minio
+status:
+  loadBalancer: {}

--- a/dstk-infra/src/skaffold.yml
+++ b/dstk-infra/src/skaffold.yml
@@ -1,0 +1,29 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: dstk
+# build:
+#   artifacts:
+#   - image: postgres
+#     context: postgres
+manifests:
+  rawYaml:
+  - minio/minio.k8s.yml
+  # - postgres/postgres.k8s.yml
+deploy:
+  kubectl: {}
+    # flags:
+    #   global:
+    #   - --namespace=dstk
+  statusCheckDeadlineSeconds: 600
+profiles:
+- name: dstk-dev
+  # patches:
+  # - op: replace
+  #   path: /deploy/kubectl/flags/global/0
+  #   value: --namespace=dstk-dev
+  portForward:
+  - resourceType: service
+    resourceName: minio
+    port: 9000
+    localPort: 9000


### PR DESCRIPTION
This is a very rough initial commit that sets up a local k8s
cluster with minikube and deploys a minimal Minio installation
onto it with kubectl/skaffold.

There's a couple things I need to circle back to and fix:
  - the minio deployment's  PVC is commented out and needs validated;
  - forwarding the service port is wonky and I need to dust off
    some k8s cobwebs and figure out why;
  - I need to play around a bit with profile-specific namespaces in
    Skaffold. I'm doing something not quite right and kubectl is
    barking at me because of it.
