### PR TITLE
Get minio console working

### DIFF
--- a/dstk-infra/bootstrap.sh
+++ b/dstk-infra/bootstrap.sh
@@ -45,4 +45,7 @@ check_binary "skaffold"
 set -e
 
 # Minikube startup
-minikube dev --profile dstk-dev
+minikube start --profile dstk
+
+pushd src
+skaffold dev --port-forward --profile dstk-dev

--- a/dstk-infra/src/minio/minio.k8s.yml
+++ b/dstk-infra/src/minio/minio.k8s.yml
@@ -19,62 +19,27 @@ spec:
         io.kompose.service: minio
         app.kubernetes.io/name: minio
     spec:
-      # initContainers:
-      # - name: install
-      #   image: alpine:latest
-      #   command:
-      #   - mkdir
-      #   - -p
-      #   - /data/dstk-registry
-      #   volumeMounts:
-      #   - name:  minio
-      #     mountPath: "/data"
+      initContainers:
+      - name: install
+        image: alpine:latest
+        command:
+        - mkdir
+        - -p
+        - /data/dstk-registry
       containers:
-        - args:
-            - server
-            - /data
-          env:
-            - name: MINIO_ROOT_USER
-              value: ACCESSKEY
-            - name: MINIO_ROOT_PASSWORD
-              value: SECRETKEY
-          image: minio/minio:latest
-          name: minio
-          ports:
-            - containerPort: 9000
-              name: minio-web
-          # volumeMounts:
-          #   - mountPath: /data
-          #     name: minio
-          resources:
-            limits:
-              cpu: 750m
-              memory: 1024Mi
-            requests:
-              cpu: 250m
-              memory: 256Mi
-
-      restartPolicy: Always
-      # volumes:
-      #   - name: minio
-      #     persistentVolumeClaim:
-      #       claimName: minio
+      - args:
+          - server
+          - /data
+          - --console-address
+          - ":9001"
+        env:
+        - name: MINIO_ROOT_USER
+          value: minioadmin
+        - name: MINIO_ROOT_PASSWORD
+          value: minioadmin
+        image: minio/minio:latest
+        name: minio
 ---
-# apiVersion: v1
-# kind: PersistentVolumeClaim
-# metadata:
-#   labels:
-#     io.kompose.service: minio
-#     app.kubernetes.io/name: minio
-#   name: minio
-# spec:
-#   accessModes:
-#     - ReadWriteOnce
-#   resources:
-#     requests:
-#       storage: 2Gi
-# status: {}
-# ---
 apiVersion: v1
 kind: Service
 metadata:
@@ -82,13 +47,8 @@ metadata:
     io.kompose.service: minio
   name: minio
 spec:
-  type: NodePort
   ports:
-    - name: "9000"
-      port: 9000
-      protocol: TCP
-      targetPort: minio-web
+    - name: "9001"
+      port: 9001
   selector:
     io.kompose.service: minio
-status:
-  loadBalancer: {}

--- a/dstk-infra/src/skaffold.yml
+++ b/dstk-infra/src/skaffold.yml
@@ -2,28 +2,11 @@ apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: dstk
-# build:
-#   artifacts:
-#   - image: postgres
-#     context: postgres
 manifests:
   rawYaml:
   - minio/minio.k8s.yml
-  # - postgres/postgres.k8s.yml
 deploy:
   kubectl: {}
-    # flags:
-    #   global:
-    #   - --namespace=dstk
   statusCheckDeadlineSeconds: 600
 profiles:
 - name: dstk-dev
-  # patches:
-  # - op: replace
-  #   path: /deploy/kubectl/flags/global/0
-  #   value: --namespace=dstk-dev
-  portForward:
-  - resourceType: service
-    resourceName: minio
-    port: 9000
-    localPort: 9000


### PR DESCRIPTION
Turned out to just be some weirdness in the args
minio was expecting. Without specifying the
--console-address arg it was assigning to a
random port that (predictably) wasn't itself getting
forwarded. Explicitly setting it corrects the issue
and makes the web console available on port 9001.
The default username/password are set in the
env vars (currently minioadmin for both).
