### PR TITLE
Add initial sql patch to validate functionality

### DIFF
--- a/dstk-infra/src/postgres/patches/20230801_registry-models-table.sql
+++ b/dstk-infra/src/postgres/patches/20230801_registry-models-table.sql
@@ -1,0 +1,13 @@
+\connect dstk_registry;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE registry_models (
+    id               SERIAL  NOT NULL PRIMARY KEY,
+    dstk_id          UUID    NOT NULL DEFAULT uuid_generate_v4(),
+    description      TEXT,
+    metadata         JSON,
+    is_archived      BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by       UUID, -- TODO: make non-nullable
+    storage_provider UUID  -- TODO: make non-nullable
+);


### PR DESCRIPTION
This adds a SQL patch to `src/postgres/patches` to verify that the
storage utility approximately works. And it does, yay! But it will
consider just about anything a success right now and that's not
great, so that's a TODO on my part but whatever, we'll get to it.

The important thing is that you can add any arbitrary SQL to the
`patches/` folder and run
```
POSTGRES_PWD=postgres ./bin/storage
```
to have the changes incrementally picked up and applied to the
database(s).

When creating new patches, just be consistent in the naming:
currently I'm using the scheme `YYYYMMDD_patch-name.sql` so that
patches are applied sequentially. I doubt we'll have a ton of
cases with multiple patches on the same day, but if/when we do,
we can just add specificity to the date qualifier. Just like
`YYYYMMDD-01_patch-name.sql` or similar. Nothing too fancy,
but still easier to parse than using UNIX epoch time 🥴
