### PR TITLE
Add storage provider and model version tables

### DIFF
--- a/dstk-infra/bin/storage
+++ b/dstk-infra/bin/storage
@@ -29,7 +29,7 @@ check_binary () {
 }
 
 query_psql () {
-  PGPASSWORD="${POSTGRES_PWD}" \
+  PGPASSWORD="postgres" \
   psql \
     -h "127.0.0.1" \
     -p "5432" \

--- a/dstk-infra/postgres/patches/20230801_registry-models-table.sql
+++ b/dstk-infra/postgres/patches/20230801_registry-models-table.sql
@@ -2,12 +2,43 @@
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
+CREATE TABLE registry_storage_providers (
+    id                SERIAL       NOT NULL PRIMARY KEY,
+    provider_id       UUID         NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    endpoint_url      VARCHAR(512) NOT NULL,
+    region            VARCHAR(32)  NOT NULL,
+    bucket            VARCHAR(64)  NOT NULL,
+    access_key_id     VARCHAR(128) NOT NULL,
+    secret_access_key VARCHAR(40)  NOT NULL,
+    created_by        UUID         NOT NULL,
+    modified_by       UUID         NOT NULL,
+    owner             UUID         NOT NULL,
+    date_created      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    date_modified     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE registry_models (
+    id                  SERIAL      NOT NULL PRIMARY KEY,
+    model_id            UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    storage_provider_id UUID        NOT NULL REFERENCES registry_storage_providers(provider_id),
+    is_archived         BOOLEAN     NOT NULL DEFAULT FALSE,
+    model_name          VARCHAR(64) NOT NULL UNIQUE,
+    created_by          UUID        NOT NULL,
+    modified_by         UUID        NOT NULL,
+    description         TEXT,
+    metadata            JSON,
+    date_created        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    date_modified       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE registry_model_versions (
     id               SERIAL  NOT NULL PRIMARY KEY,
-    model_id         UUID    NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    model_version_id UUID    NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    model_id         UUID    NOT NULL REFERENCES registry_models(model_id),
+    is_archived      BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by       UUID    NOT NULL,
+    numeric_version  INTEGER NOT NULL,
     description      TEXT,
     metadata         JSON,
-    is_archived      BOOLEAN NOT NULL DEFAULT FALSE,
-    created_by       UUID, -- TODO: make non-nullable
-    storage_provider UUID  -- TODO: make non-nullable
+    date_created     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
This commit adds the `CREATE TABLE` statements for both the
`registry_storage_providers` and `registry_model_versions` tables,
and updates `registry_models` to use a proper foreign key to
reference storage providers
