### PR TITLE
Use service DNS resolution for psql connection

### DIFF
--- a/dstk-infra/apollo/apollo.k8s.yml
+++ b/dstk-infra/apollo/apollo.k8s.yml
@@ -2,24 +2,24 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    io.kompose.service: apollo
-    app.kubernetes.io/name: apollo
-  name: apollo
+    io.kompose.service: dstk-apollo
+    app.kubernetes.io/name: dstk-apollo
+  name: dstk-apollo
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: apollo
+      io.kompose.service: dstk-apollo
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        io.kompose.service: apollo
-        app.kubernetes.io/name: apollo
+        io.kompose.service: dstk-apollo
+        app.kubernetes.io/name: dstk-apollo
     spec:
       containers:
-        - name: apollo
+        - name: dstk-apollo
           image: dstk-apollo
 
 ---
@@ -27,11 +27,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    io.kompose.service: apollo
-  name: apollo
+    io.kompose.service: dstk-apollo
+  name: dstk-apollo
 spec:
   ports:
     - name: "4000"
       port: 4000
   selector:
-    io.kompose.service: apollo
+    io.kompose.service: dstk-apollo

--- a/dstk-infra/apollo/src/knexfile.ts
+++ b/dstk-infra/apollo/src/knexfile.ts
@@ -4,7 +4,7 @@ export const knexConfig = {
   development: {
     client: 'postgresql',
     connection: {
-      host: '127.0.0.1',
+      host: 'dstk-postgres.svc.cluster.local',
       port: 5432,
       user: 'postgres',
       password: 'postgres',

--- a/dstk-infra/minio/minio.k8s.yml
+++ b/dstk-infra/minio/minio.k8s.yml
@@ -3,21 +3,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    io.kompose.service: minio
-    app.kubernetes.io/name: minio
-  name: minio
+    io.kompose.service: dstk-minio
+    app.kubernetes.io/name: dstk-minio
+  name: dstk-minio
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: minio
+      io.kompose.service: dstk-minio
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        io.kompose.service: minio
-        app.kubernetes.io/name: minio
+        io.kompose.service: dstk-minio
+        app.kubernetes.io/name: dstk-minio
     spec:
       initContainers:
       - name: install
@@ -38,17 +38,17 @@ spec:
         - name: MINIO_ROOT_PASSWORD
           value: minioadmin
         image: minio/minio:latest
-        name: minio
+        name: dstk-minio
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    io.kompose.service: minio
-  name: minio
+    io.kompose.service: dstk-minio
+  name: dstk-minio
 spec:
   ports:
     - name: "9001"
       port: 9001
   selector:
-    io.kompose.service: minio
+    io.kompose.service: dstk-minio

--- a/dstk-infra/postgres/postgres.k8s.yml
+++ b/dstk-infra/postgres/postgres.k8s.yml
@@ -3,8 +3,8 @@ kind: Secret
 metadata:
   name: postgres-secret
   labels:
-    io.kompose.service: postgres
-    app.kubernetes.io/name: postgres
+    io.kompose.service: dstk-postgres
+    app.kubernetes.io/name: dstk-postgres
 data:
   postgres-user: cG9zdGdyZXM=
   postgres-password: cG9zdGdyZXM=
@@ -14,21 +14,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    io.kompose.service: postgres
-    app.kubernetes.io/name: postgres
-  name: postgres
+    io.kompose.service: dstk-postgres
+    app.kubernetes.io/name: dstk-postgres
+  name: dstk-postgres
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: postgres
+      io.kompose.service: dstk-postgres
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        io.kompose.service: postgres
-        app.kubernetes.io/name: postgres
+        io.kompose.service: dstk-postgres
+        app.kubernetes.io/name: dstk-postgres
     spec:
       containers:
         - name: postgres
@@ -50,11 +50,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    io.kompose.service: postgres
-  name: postgres
+    io.kompose.service: dstk-postgres
+  name: dstk-postgres
 spec:
   ports:
     - name: "5432"
       port: 5432
   selector:
-    io.kompose.service: postgres
+    io.kompose.service: dstk-postgres

--- a/dstk-infra/skaffold.yml
+++ b/dstk-infra/skaffold.yml
@@ -24,14 +24,14 @@ profiles:
 - name: dstk-dev
   portForward:
     - resourceType: service
-      resourceName: apollo
+      resourceName: dstk-apollo
       port: 4000
       localPort: 4000
     - resourceType: service
-      resourceName: minio
+      resourceName: dstk-minio
       port: 9001
       localPort: 9001
     - resourceType: service
-      resourceName: postgres
+      resourceName: dstk-postgres
       port: 5432
       localPort: 5432


### PR DESCRIPTION
This changes the postgres host in our knex config to reference
the postgres service's A record instead of relying on a bare
IP address. Ref https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/

I'll circle back later to clean a few things up once I start
properly namespacing everything
