### PR TITLE
Nexus & Objection for `dstk_registry.registry_storage_providers`

### DIFF
--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -1,1 +1,2 @@
 export * from './model/model.js';
+export * from './storage-provider/storageProvider.js';

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -1,0 +1,38 @@
+import { objectType } from 'nexus';
+import { Model } from 'objection';
+
+export const StorageProvider = objectType({
+    name: 'StorageProvider',
+    definition(t) {
+        t.id('providerId');
+        t.string('endpointUrl');
+        t.string('region');
+        t.string('bucket');
+        t.string('accessKeyId');
+        t.string('secretAccessKey');
+        t.string('createdBy'); // TODO: resolve actual user object
+        t.string('modifiedBy');
+        t.string('owner');
+        t.string('dateCreated');
+        t.string('dateModified');
+    },
+});
+
+export class ObjectionStorageProvider extends Model {
+    id!: string;
+    endpointUrl!: string;
+    region!: string;
+    bucket!: string;
+    accessKeyId!: string;
+    secretAccessKey!: string;
+    createdBy!: string;
+    modifiedBy!: string;
+    owner!: string;
+    dateCreated!: string;
+    dateModified!: string;
+
+    static TableName = 'registryStorageProviders';
+    static get idColumn() {
+        return 'providerId';
+    }
+}


### PR DESCRIPTION
Added the Nexus and Objection code for the `dstk_registry.registry_storage_providers` table.

Edit: Just realized I should add the modifiers and fields for the relationship between `dstk_registry.registry_storage_providers` and `dstk_registry.registry_models`. I'll re-push with those changes.