### PR TITLE
Add model and storage provider relationship

### DIFF
--- a/dstk-infra/apollo/src/graphql/model/model.ts
+++ b/dstk-infra/apollo/src/graphql/model/model.ts
@@ -27,7 +27,6 @@ export const MLModel = objectType({
 export class ObjectionMLModel extends Model {
     id!: string;
     storageProviderId!: string;
-    storageProvider: ObjectionStorageProvider;
     isArchived!: boolean;
     modelName!: string;
     createdBy!: string;

--- a/dstk-infra/apollo/src/graphql/model/model.ts
+++ b/dstk-infra/apollo/src/graphql/model/model.ts
@@ -1,36 +1,43 @@
-import { objectType } from 'nexus'
-import { Model } from 'objection'
+import { objectType } from 'nexus';
+import { Model } from 'objection';
+import { ObjectionStorageProvider } from '../storage-provider/storageProvider';
 
 export const MLModel = objectType({
     name: 'Model',
     definition(t) {
-        t.id('modelId')
-        t.string('storageProviderId')
-        t.boolean('isArchived')
-        t.string('modelName')
-        t.string('createdBy') // TODO: resolve actual user object
-        t.string('modifiedBy')
-        t.string('dateCreated')
-        t.string('dateModified')
-        t.string('description')
+        t.id('modelId');
+        t.field('storageProvider', {
+            type: 'StorageProvider',
+            async resolve(root, _args, _ctx) {
+                ObjectionStorageProvider.query().findById(root.providerId).first();
+            },
+        });
+        t.boolean('isArchived');
+        t.string('modelName');
+        t.string('createdBy'); // TODO: resolve actual user object
+        t.string('modifiedBy');
+        t.string('dateCreated');
+        t.string('dateModified');
+        t.string('description');
         // holding off on metadata bc I don't want to deal
         // with JSON serialization/deserialization right now
     },
-})
+});
 
 export class ObjectionMLModel extends Model {
-    id!: string
-    storageProviderId!: string
-    isArchived!: boolean
-    modelName!: string
-    createdBy!: string
-    modifiedBy!: string
-    dateCreated!: string
-    dateModified!: string
-    description!: string
+    id!: string;
+    storageProviderId!: string;
+    storageProvider: ObjectionStorageProvider;
+    isArchived!: boolean;
+    modelName!: string;
+    createdBy!: string;
+    modifiedBy!: string;
+    dateCreated!: string;
+    dateModified!: string;
+    description!: string;
 
-    static tableName = 'registryModels'
+    static tableName = 'registryModels';
     static get idColumn() {
         return 'modelId';
-      }
+    }
 }

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -1,5 +1,6 @@
 import { objectType } from 'nexus';
 import { Model } from 'objection';
+import { ObjectionMLModel } from '../model/model';
 
 export const StorageProvider = objectType({
     name: 'StorageProvider',
@@ -35,4 +36,15 @@ export class ObjectionStorageProvider extends Model {
     static get idColumn() {
         return 'providerId';
     }
+
+    static relationMappings = () => ({
+        models: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionMLModel,
+            join: {
+                from: 'registryStorageProviders.id',
+                to: 'registryModels.id',
+            },
+        },
+    });
 }

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -43,7 +43,7 @@ export class ObjectionStorageProvider extends Model {
             modelClass: ObjectionMLModel,
             join: {
                 from: 'registryStorageProviders.id',
-                to: 'registryModels.id',
+                to: 'registryModels.storageProviderId',
             },
         },
     });


### PR DESCRIPTION
Adds the one-to-many relationship between `dstk_registry.registry_storage_providers` and `dstk_registry.registry_models`. 

PS: The semi-colons introduced in `model.ts` are from the `.prettierrc.json` config.