### PR TITLE
Add couple storage provider queries

### DIFF
--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -1,2 +1,4 @@
 export * from './model/model.js';
+
 export * from './storage-provider/storageProvider.js';
+export * from './storage-provider/storageProviderQueries.js';

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -31,7 +31,7 @@ export class ObjectionStorageProvider extends Model {
     dateCreated!: string;
     dateModified!: string;
 
-    static TableName = 'registryStorageProviders';
+    static tableName = 'registryStorageProviders';
     static get idColumn() {
         return 'providerId';
     }

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -1,0 +1,33 @@
+import { extendType, stringArg, nonNull } from 'nexus';
+import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
+
+export const ListStorageProviders = extendType({
+    type: 'Query',
+    definition(t) {
+        t.nonNull.list.field('listStorageProviders', {
+            type: StorageProvider,
+            async resolve(root, args, ctx) {
+                let query = ObjectionStorageProvider.query();
+                const result = await query.orderBy('dateCreated');
+                return result;
+            },
+        });
+    },
+});
+
+export const GetStorageProvider = extendType({
+    type: 'Query',
+    definition(t) {
+        t.nonNull.list.field('getStorageProvider', {
+            type: StorageProvider,
+            args: {
+                id: nonNull(stringArg()),
+            },
+            async resolve(root, args, ctx) {
+                // TODO: need to mask access key ID and
+                // secret access key
+                return await ObjectionStorageProvider.query().findById(args.id);
+            },
+        });
+    },
+});


### PR DESCRIPTION
This adds a list and get query for storage providers, and
corrects a typo in the storage provider objection stuff.

Looks like some funkiness after all with DNS resolution:
```
getaddrinfo ENOTFOUND dstk-postgres.svc.cluster.local
```
when trying to run one of the GQL queries. Saving that
for another commit...
