### PR TITLE
Change hostname to reference kubectl deployment name in knex config

### DIFF
--- a/dstk-infra/apollo/src/knexfile.ts
+++ b/dstk-infra/apollo/src/knexfile.ts
@@ -2,9 +2,9 @@ import { knexSnakeCaseMappers } from "objection"
 
 export const knexConfig = {
   development: {
-    client: 'postgresql',
+    client: 'pg',
     connection: {
-      host: 'dstk-postgres.svc.cluster.local',
+      host: 'dstk-postgres',
       port: 5432,
       user: 'postgres',
       password: 'postgres',


### PR DESCRIPTION
Fixes the issue in https://github.com/wetherc/dstk/pull/18#issue-1844095222

The hostname in the `knexConfig` needs to reference the name of the postgres kubernetes deployment `dstk-postgres`, which can be found by running `kubectl get deployments`:

<img width="383" alt="image" src="https://github.com/wetherc/dstk/assets/77359138/eae99bd0-6a62-4fef-a68f-0979ef372582">

Also also, changed the client parameter to `pg` as this is the appropriate postgresql client according to the knex docs.
 