### PR TITLE
Resolve module imports for model and storageProvider

### DIFF
--- a/dstk-infra/apollo/src/graphql/model/model.ts
+++ b/dstk-infra/apollo/src/graphql/model/model.ts
@@ -1,6 +1,6 @@
 import { objectType } from 'nexus';
 import { Model } from 'objection';
-import { ObjectionStorageProvider } from '../storage-provider/storageProvider';
+import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
 
 export const MLModel = objectType({
     name: 'Model',

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -1,6 +1,6 @@
 import { objectType } from 'nexus';
 import { Model } from 'objection';
-import { ObjectionMLModel } from '../model/model';
+import { ObjectionMLModel } from '../model/model.js';
 
 export const StorageProvider = objectType({
     name: 'StorageProvider',


### PR DESCRIPTION
Added missing `.js` extension in `model.ts` and `storageProvider.ts`

Not really sure when this happened b/c I'm way too lazy to go through the commit history right now.

@wetherc any thoughts on adding eslint to this directory? It will help with catching silly things like this. If yes, I can also setup some pre-commit hooks for eslint and prettier so the changes will be applied automatically on commits.

Edit: English is really hard.