### PR TITLE
Add GraphQL Schema for Model Registry Versions Table

### DIFF
--- a/dstk-infra/apollo/.eslintrc.json
+++ b/dstk-infra/apollo/.eslintrc.json
@@ -2,5 +2,14 @@
     "parser": "@typescript-eslint/parser",
     "extends": ["plugin:@typescript-eslint/recommended"],
     "parserOptions": { "ecmaVersion": 2018, "sourceType": "module" },
-    "rules": {}
+    "rules": {
+        "@typescript-eslint/no-unused-vars": [
+            "warn",
+            {
+              "argsIgnorePattern": "^_",
+              "varsIgnorePattern": "^_",
+              "caughtErrorsIgnorePattern": "^_"
+            }
+          ]
+    }
 }

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
@@ -1,0 +1,38 @@
+import { objectType } from 'nexus';
+import { MLModel, ObjectionMLModel } from '../model/model';
+import { Model } from 'objection';
+
+export const MLModelVersion = objectType({
+    name: 'MLModel',
+    definition(t) {
+        t.id('modelVersionId');
+        t.field('modelId', {
+            type: MLModel,
+            async resolve(root: ObjectionMLModelVersion, _args, _ctx) {
+                ObjectionMLModel.query().findById(root.modelId).first();
+            },
+        });
+        t.boolean('isArchived');
+        t.string('createdBy'); // TODO: Resolve actual user object
+        t.int('numericVersion');
+        t.string('description');
+        // TODO: Custom Scalar Type for JSON Object: t.something('metadata')
+        t.string('dateCreated');
+    },
+});
+
+export class ObjectionMLModelVersion extends Model {
+    id!: string;
+    modelId!: string;
+    isArchived!: boolean;
+    createdBy!: string;
+    numericVersion!: number;
+    description: string;
+    // TODO: metadata: something
+    dateCreated!: string;
+
+    static tableName = 'registryModelVersions';
+    static get idColumn() {
+        return 'modelVersionId';
+    }
+}


### PR DESCRIPTION
Added the Objection.js class representation and the GraphQL schema for the Registry Model Versions table. Still need to resolve the actual User object and need to add the serialization / deserialization for the metadata JSON blob.

Also also, added a rule to ESLint that allows us to ignore unused variables by prefixing it with an underscore.