### PR TITLE
Migrate from separate dbs to separate schemas

### DIFF
--- a/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
@@ -31,7 +31,7 @@ export class ObjectionMLModelVersion extends Model {
     // TODO: metadata: something
     dateCreated!: string;
 
-    static tableName = 'registryModelVersions';
+    static tableName = 'registry.modelVersions';
     static get idColumn() {
         return 'modelVersionId';
     }

--- a/dstk-infra/apollo/src/graphql/model/model.ts
+++ b/dstk-infra/apollo/src/graphql/model/model.ts
@@ -35,7 +35,7 @@ export class ObjectionMLModel extends Model {
     dateModified!: string;
     description!: string;
 
-    static tableName = 'registryModels';
+    static tableName = 'registry.models';
     static get idColumn() {
         return 'modelId';
     }

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -32,7 +32,7 @@ export class ObjectionStorageProvider extends Model {
     dateCreated!: string;
     dateModified!: string;
 
-    static tableName = 'registryStorageProviders';
+    static tableName = 'registry.storageProviders';
     static get idColumn() {
         return 'providerId';
     }
@@ -42,8 +42,8 @@ export class ObjectionStorageProvider extends Model {
             relation: Model.HasManyRelation,
             modelClass: ObjectionMLModel,
             join: {
-                from: 'registryStorageProviders.id',
-                to: 'registryModels.storageProviderId',
+                from: 'registry.storageProviders.id',
+                to: 'registry.models.storageProviderId',
             },
         },
     });

--- a/dstk-infra/apollo/src/knexfile.ts
+++ b/dstk-infra/apollo/src/knexfile.ts
@@ -1,19 +1,19 @@
-import { knexSnakeCaseMappers } from "objection"
+import { knexSnakeCaseMappers } from 'objection';
 
 export const knexConfig = {
-  development: {
-    client: 'pg',
-    connection: {
-      host: 'dstk-postgres',
-      port: 5432,
-      user: 'postgres',
-      password: 'postgres',
-      database: 'dstk_registry',
+    development: {
+        client: 'pg',
+        connection: {
+            host: 'dstk-postgres',
+            port: 5432,
+            user: 'postgres',
+            password: 'postgres',
+            database: 'dstk',
+        },
+        pool: {
+            min: 2,
+            max: 10,
+        },
+        ...knexSnakeCaseMappers(),
     },
-    pool: {
-      min: 2,
-      max: 10,
-    },
-    ...knexSnakeCaseMappers()
-  },
-}
+};

--- a/dstk-infra/bin/storage
+++ b/dstk-infra/bin/storage
@@ -61,7 +61,7 @@ storage__readiness() {
 
   #  Test database connection
   info "checking postgres availability"
-  pg_isready -d dstk_metadata -h 127.0.0.1 -p 5432 -U postgres &> /dev/null
+  pg_isready -d dstk -h 127.0.0.1 -p 5432 -U postgres &> /dev/null
   success "Connected to postgres!"
 }
 
@@ -86,7 +86,7 @@ storage__upgrade() {
     # Check to see if this is a patch that has already been applied or not
     info "Checking patch ${base_name}"
     query="SELECT patch, applied FROM patch_status WHERE patch = '${base_name}';"
-    IFS="|" read -r -a res <<< $(echo "${query}" | query_psql "dstk_metadata")
+    IFS="|" read -r -a res <<< $(echo "${query}" | query_psql "dstk")
 
     # If the result set is length 0, meaning that the patch doesn't exist
     # in our `patch_status` table, we will attempt to apply it
@@ -103,7 +103,7 @@ storage__upgrade() {
       # I don't know, checking to see if the transaction failed or succeeded.
       # We're just kind of winging it and assuming things mostly worked out
       # for the best.
-      result=$(echo "${query}" | query_psql "dstk_metadata")
+      result=$(echo "${query}" | query_psql "dstk")
       success "Applied patch ${base_name} in ${duration} seconds"
     else
       info "Patch ${base_name} already applied, skipping"

--- a/dstk-infra/postgres/docker-entrypoint-initdb.d/000_create-dbs.sql
+++ b/dstk-infra/postgres/docker-entrypoint-initdb.d/000_create-dbs.sql
@@ -1,4 +1,1 @@
-CREATE DATABASE dstk_metadata;
-CREATE DATABASE dstk_registry;
-CREATE DATABASE dstk_deployments;
-CREATE DATABASE dstk_user;
+CREATE DATABASE dstk;

--- a/dstk-infra/postgres/docker-entrypoint-initdb.d/010_create-patch-tables.sql
+++ b/dstk-infra/postgres/docker-entrypoint-initdb.d/010_create-patch-tables.sql
@@ -1,5 +1,8 @@
-\connect dstk_metadata
-CREATE TABLE patch_status (
+\connect dstk
+
+CREATE SCHEMA metadata;
+
+CREATE TABLE metadata.patch_status (
     patch    VARCHAR(100) NOT NULL PRIMARY KEY,
     applied  BOOLEAN NOT NULL DEFAULT FALSE,
     duration INTEGER

--- a/dstk-infra/postgres/patches/20230801_registry-models-table.sql
+++ b/dstk-infra/postgres/patches/20230801_registry-models-table.sql
@@ -1,8 +1,10 @@
-\connect dstk_registry;
+\connect dstk;
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE registry_storage_providers (
+CREATE SCHEMA registry;
+
+CREATE TABLE registry.storage_providers (
     id                SERIAL       NOT NULL PRIMARY KEY,
     provider_id       UUID         NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
     endpoint_url      VARCHAR(512) NOT NULL,
@@ -17,10 +19,10 @@ CREATE TABLE registry_storage_providers (
     date_modified     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE registry_models (
+CREATE TABLE registry.models (
     id                  SERIAL      NOT NULL PRIMARY KEY,
     model_id            UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
-    storage_provider_id UUID        NOT NULL REFERENCES registry_storage_providers(provider_id),
+    storage_provider_id UUID        NOT NULL REFERENCES registry.storage_providers(provider_id),
     is_archived         BOOLEAN     NOT NULL DEFAULT FALSE,
     model_name          VARCHAR(64) NOT NULL UNIQUE,
     created_by          UUID        NOT NULL,
@@ -31,10 +33,10 @@ CREATE TABLE registry_models (
     date_modified       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE registry_model_versions (
+CREATE TABLE registry.model_versions (
     id               SERIAL  NOT NULL PRIMARY KEY,
     model_version_id UUID    NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
-    model_id         UUID    NOT NULL REFERENCES registry_models(model_id),
+    model_id         UUID    NOT NULL REFERENCES registry.models(model_id),
     is_archived      BOOLEAN NOT NULL DEFAULT FALSE,
     created_by       UUID    NOT NULL,
     numeric_version  INTEGER NOT NULL,

--- a/dstk-infra/postgres/patches/20230803_users.sql
+++ b/dstk-infra/postgres/patches/20230803_users.sql
@@ -2,7 +2,9 @@
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE dstk_user (
+CREATE SCHEMA user;
+
+CREATE TABLE user.user (
     id                SERIAL  NOT NULL PRIMARY KEY,
     user_id           UUID    NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
     is_admin          BOOLEAN NOT NULL DEFAULT FALSE,
@@ -16,10 +18,10 @@ CREATE TABLE dstk_user (
     date_modified     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE user_email (
+CREATE TABLE user.email (
     id                SERIAL       NOT NULL PRIMARY KEY,
     email_id          UUID         NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
-    user_id           UUID         NOT NULL REFERENCES dstk_user(user_id),
+    user_id           UUID         NOT NULL REFERENCES user.user(user_id),
     email_address     VARCHAR(128) NOT NULL UNIQUE,
     is_verified       BOOLEAN      NOT NULL DEFAULT FALSE,
     is_primary        BOOLEAN      NOT NULL,
@@ -28,22 +30,22 @@ CREATE TABLE user_email (
     date_modified     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE user_session(
+CREATE TABLE user.session (
     id              SERIAL      NOT NULL PRIMARY KEY,
     session_id      UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
-    user_id         UUID        NOT NULL REFERENCES dstk_user(user_id),
+    user_id         UUID        NOT NULL REFERENCES user.user(user_id),
     is_partial      BOOLEAN     NOT NULL,
     session_key     VARCHAR(64) NOT NULL,
     session_expires TIMESTAMP WITH TIME ZONE NOT NULL,
     sesstion_start  TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
-CREATE TABLE user_log (
+CREATE TABLE user.log (
     id            SERIAL NOT NULL PRIMARY KEY,
     log_id        UUID   NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
     user_id       UUID   NOT NULL REFERENCES dstk_user(user_id),
     actor_id      UUID   NOT NULL REFERENCES dstk_user(user_id),
-    session_id    UUID   NOT NULL REFERENCES user_session(session_id),
+    session_id    UUID   NOT NULL REFERENCES user.session(session_id),
     old_value     TEXT   NOT NULL,
     new_value     TEXT   NOT NULL,
     remote_addr   INET   NOT NULL,


### PR DESCRIPTION
This just makes our lives easier by ripping out some early
overengineering that I did. Instead of having separate
databases for easier eventual theoretical crazy large
scale deployments, we've just got everything in a single
database now with separate schemas for metadata, registry
stuff, and user stuff. It's all easily joinable across
schema and we still get benefits of easy schema-level
permissioning.
