### PR TITLE
Add CreateStorageProvider mutation

### DIFF
--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -2,3 +2,4 @@ export * from './model/model.js';
 
 export * from './storage-provider/storageProvider.js';
 export * from './storage-provider/storageProviderQueries.js';
+export * from './storage-provider/storageProviderMutations.js';

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -1,0 +1,40 @@
+import { extendType, inputObjectType, nonNull } from 'nexus';
+import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
+
+export const StorageProviderInputType = inputObjectType({
+    name: 'StorageProviderInputType',
+    definition(t) {
+        t.nonNull.string('endpointUrl');
+        t.nonNull.string('region');
+        t.nonNull.string('bucket');
+        t.nonNull.string('accessKeyId');
+        t.nonNull.string('secretAccessKey');
+    },
+});
+
+export const CreateStorageProviderMutation = extendType({
+    type: 'Mutation',
+    definition(t) {
+        t.field('createStorageProvider', {
+            type: StorageProvider,
+            args: { data: StorageProviderInputType },
+            async resolve(root, args, ctx) {
+                const results = ObjectionStorageProvider.transaction(async (trx) => {
+                    const storageProvider = await ObjectionStorageProvider.query(trx)
+                        .insertAndFetch({
+                            endpointUrl: args.data.endpointUrl,
+                            region: args.data.region,
+                            bucket: args.data.bucket,
+                            accessKeyId: args.data.accessKeyId,
+                            secretAccessKey: args.data.secretAccessKey,
+                        })
+                        .first();
+
+                    return storageProvider;
+                });
+
+                return results;
+            },
+        });
+    },
+});


### PR DESCRIPTION
This adds a GQL mutation to create a new storage provider in
the model registry.

To test, I ran the mutation with the following data:
```
{
  "data": {
    "accessKeyId": "flarp",
    "bucket": "flarp",
    "endpointUrl": "flarp",
    "region": "flarp",
    "secretAccessKey": "flarp"
  }
}

mutation Mutation($data: StorageProviderInputType) {
  createStorageProvider(data: $data) {
    accessKeyId
    bucket
    dateCreated
    endpointUrl
    providerId
    region
  }
}
```

which returned a valid and expected output:
```json
{
  "data": {
    "createStorageProvider": {
      "accessKeyId": "flarp",
      "bucket": "flarp",
      "dateCreated": "1702419675057",
      "endpointUrl": "flarp",
      "providerId": "dd0156d0-ea00-4ebe-bb98-71091c566074",
      "region": "flarp"
    }
  }
}
```

I verified that the existing query methods also worked as expected:
```
query Query {
  listStorageProviders {
    bucket
    accessKeyId
    providerId
    region
    secretAccessKey
    dateCreated
  }
}
```

correctly returned
```json
{
  "data": {
    "listStorageProviders": [
      {
        "bucket": "asdf",
        "accessKeyId": "asdf",
        "providerId": "e2081d2f-693a-4ea9-b57e-50f3dfc5a99c",
        "region": "asdf",
        "secretAccessKey": "asdf",
        "dateCreated": "1702419301387"
      },
      {
        "bucket": "flarp",
        "accessKeyId": "flarp",
        "providerId": "dd0156d0-ea00-4ebe-bb98-71091c566074",
        "region": "flarp",
        "secretAccessKey": "flarp",
        "dateCreated": "1702419675057"
      }
    ]
  }
}
```
