### PR TITLE
Add EditStorageProvider mutation

### DIFF
--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -27,7 +27,6 @@ export const CreateStorageProviderMutation = extendType({
             args: { data: StorageProviderInputType },
             async resolve(root, args, ctx) {
                 const results = ObjectionStorageProvider.transaction(async (trx) => {
-                    const modifiedDate = Date.now().toString();
                     const storageProvider = await ObjectionStorageProvider.query(trx)
                         .insertAndFetch({
                             endpointUrl: args.data.endpointUrl,
@@ -35,7 +34,6 @@ export const CreateStorageProviderMutation = extendType({
                             bucket: args.data.bucket,
                             accessKeyId: args.data.accessKeyId,
                             secretAccessKey: args.data.secretAccessKey,
-                            dateModified: modifiedDate,
                         })
                         .first();
 
@@ -59,6 +57,7 @@ export const EditStorageProviderMutation = extendType({
             },
             async resolve(root, args, ctx) {
                 const results = ObjectionStorageProvider.transaction(async (trx) => {
+                    const modifiedDate = Date.now().toString();
                     const storageProvider = await ObjectionStorageProvider.query(
                         trx,
                     ).patchAndFetchById(args.providerId.providerId, {
@@ -67,6 +66,7 @@ export const EditStorageProviderMutation = extendType({
                         bucket: args.data.bucket,
                         accessKeyId: args.data.accessKeyId,
                         secretAccessKey: args.data.secretAccessKey,
+                        dateModified: modifiedDate,
                     });
 
                     return storageProvider;

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -27,6 +27,7 @@ export const CreateStorageProviderMutation = extendType({
             args: { data: StorageProviderInputType },
             async resolve(root, args, ctx) {
                 const results = ObjectionStorageProvider.transaction(async (trx) => {
+                    const modifiedDate = Date.now().toString();
                     const storageProvider = await ObjectionStorageProvider.query(trx)
                         .insertAndFetch({
                             endpointUrl: args.data.endpointUrl,
@@ -34,6 +35,7 @@ export const CreateStorageProviderMutation = extendType({
                             bucket: args.data.bucket,
                             accessKeyId: args.data.accessKeyId,
                             secretAccessKey: args.data.secretAccessKey,
+                            dateModified: modifiedDate,
                         })
                         .first();
 

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -2,13 +2,20 @@ import { extendType, inputObjectType, nonNull } from 'nexus';
 import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
 
 export const StorageProviderInputType = inputObjectType({
-    name: 'StorageProviderInputType',
+    name: 'StorageProviderInput',
     definition(t) {
         t.nonNull.string('endpointUrl');
         t.nonNull.string('region');
         t.nonNull.string('bucket');
         t.nonNull.string('accessKeyId');
         t.nonNull.string('secretAccessKey');
+    },
+});
+
+export const StorageProviderIdInputType = inputObjectType({
+    name: 'StorageProviderId',
+    definition(t) {
+        t.nonNull.string('providerId');
     },
 });
 
@@ -29,6 +36,36 @@ export const CreateStorageProviderMutation = extendType({
                             secretAccessKey: args.data.secretAccessKey,
                         })
                         .first();
+
+                    return storageProvider;
+                });
+
+                return results;
+            },
+        });
+    },
+});
+
+export const EditStorageProviderMutation = extendType({
+    type: 'Mutation',
+    definition(t) {
+        t.field('editStorageProvider', {
+            type: StorageProvider,
+            args: {
+                providerId: StorageProviderIdInputType,
+                data: StorageProviderInputType,
+            },
+            async resolve(root, args, ctx) {
+                const results = ObjectionStorageProvider.transaction(async (trx) => {
+                    const storageProvider = await ObjectionStorageProvider.query(
+                        trx,
+                    ).patchAndFetchById(args.providerId.providerId, {
+                        endpointUrl: args.data.endpointUrl,
+                        region: args.data.region,
+                        bucket: args.data.bucket,
+                        accessKeyId: args.data.accessKeyId,
+                        secretAccessKey: args.data.secretAccessKey,
+                    });
 
                     return storageProvider;
                 });

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -7,7 +7,7 @@ export const ListStorageProviders = extendType({
         t.nonNull.list.field('listStorageProviders', {
             type: StorageProvider,
             async resolve(root, args, ctx) {
-                let query = ObjectionStorageProvider.query();
+                const query = ObjectionStorageProvider.query();
                 const result = await query.orderBy('dateCreated');
                 return result;
             },

--- a/dstk-infra/apollo/src/index.ts
+++ b/dstk-infra/apollo/src/index.ts
@@ -1,51 +1,50 @@
-import { makeSchema } from 'nexus'
-import { Request } from 'express'
-import { ApolloServer } from '@apollo/server'
-import { startStandaloneServer } from '@apollo/server/standalone'
-import { Model } from 'objection'
-import Knex from 'knex'
-import { knexConfig } from './knexfile.js'
-import path from 'path'
-import { fileURLToPath } from 'url'
-import * as types from './graphql/index.js'
+import { makeSchema } from 'nexus';
+import { Request } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { startStandaloneServer } from '@apollo/server/standalone';
+import { Model } from 'objection';
+import Knex from 'knex';
+import { knexConfig } from './knexfile.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as types from './graphql/index.js';
 
-
-const knex = Knex(knexConfig.development)
-Model.knex(knex)
+const knex = Knex(knexConfig.development);
+Model.knex(knex);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const schema = makeSchema({
-  types,
-  outputs: {
-    schema: path.join(__dirname, '../schema.graphql'),
-    typegen: path.join(__dirname, 'typegen.ts'),
-  },
-  // sourceTypes: {
-  //   modules: [
-  //     {
-  //       module: path.join(__dirname, 'typeDefs.js'),
-  //       alias: 't',
-  //     },
-  //   ],
-  // },
-  contextType: {
-    module: path.join(__dirname, 'context.js'),
-    export: 'Context',
-  },
-})
+    types,
+    outputs: {
+        schema: path.join(__dirname, '../schema.graphql'),
+        typegen: path.join(__dirname, 'typegen.ts'),
+    },
+    // sourceTypes: {
+    //   modules: [
+    //     {
+    //       module: path.join(__dirname, 'typeDefs.js'),
+    //       alias: 't',
+    //     },
+    //   ],
+    // },
+    contextType: {
+        module: path.join(__dirname, 'context.js'),
+        export: 'Context',
+    },
+});
 
 const context = async ({ req }: { req: Request }) => {
-  // simple auth check on every request
-  const auth = (req.headers && req.headers.authorization) || ''
-  return null
-}
+    // simple auth check on every request
+    const auth = (req.headers && req.headers.authorization) || '';
+    return null;
+};
 
 const server = new ApolloServer({
-  schema,
+    schema,
 });
 
 const { url } = await startStandaloneServer(server, {
-  listen: { port: 4000 },
+    listen: { port: 4000 },
 });
 
 console.log(`🚀  Server ready at: ${url}`);


### PR DESCRIPTION
Refs #25

This adds a new editStorageProvider GQL mutation. In the GQL, I'm
reusing the same StorageProviderInput type in which all fields are
required to be non-null. I'm assuming that in the client we'll
handle merging the existing field values with the updates ones
so that the end user doesn't actually have to fill out the unchanged
fields themselves.

Tested and confirmed to be working with a createStorageProvider
followed by editStorageProvider. Data passed to each mutation:
```
{
  "data": {
    "accessKeyId": "asdf",
    "bucket": "asdf",
    "endpointUrl": "asdf",
    "region": "asdf",
    "secretAccessKey": "asdf"
  },
  "providerId": {
    "providerId": "3bf8a6fd-2a15-4067-aa6d-a3ef1391fbcb"
  },
  "editStorageProviderData": {
    "accessKeyId": "flarp",
    "bucket": "flarp",
    "endpointUrl": "flarp",
    "region": "asdf",
    "secretAccessKey": "asdf"
  }
}
```

and the results of each, sequentially:
```json
{
  "data": {
    "createStorageProvider": {
      "accessKeyId": "asdf",
      "bucket": "asdf",
      "providerId": "3bf8a6fd-2a15-4067-aa6d-a3ef1391fbcb",
      "region": "asdf",
      "secretAccessKey": "asdf",
      "dateCreated": "1702421710186",
      "endpointUrl": "asdf",
      "dateModified": "1702421710186"
    }
  }
}

{
  "data": {
    "editStorageProvider": {
      "accessKeyId": "flarp",
      "bucket": "flarp",
      "dateCreated": "1702421710186",
      "dateModified": "1702421710186",
      "endpointUrl": "flarp",
      "providerId": "3bf8a6fd-2a15-4067-aa6d-a3ef1391fbcb",
      "region": "asdf",
      "secretAccessKey": "asdf"
    }
  }
}
```
