### PR TITLE
Add DeleteStorageProvider method

### DIFF
--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -77,3 +77,28 @@ export const EditStorageProviderMutation = extendType({
         });
     },
 });
+
+export const DeleteStorageProviderMutation = extendType({
+    type: 'Mutation',
+    definition(t) {
+        t.field('deleteStorageProvider', {
+            type: StorageProvider,
+            args: {
+                providerId: StorageProviderIdInputType,
+            },
+            async resolve(root, args, ctx) {
+                const results = ObjectionStorageProvider.transaction(async (trx) => {
+                    const modifiedDate = Date.now().toString();
+                    const storageProvider = await ObjectionStorageProvider.query(trx).deleteById(
+                        args.providerId.providerId,
+                    );
+
+                    return storageProvider;
+                });
+
+                // Returns the number of rows deleted
+                return results;
+            },
+        });
+    },
+});


### PR DESCRIPTION
Refs. #25

Does what it says on the tin. Normally we're in favor of just
archiving objects with an `is_archived` boolean in the database;
however, in this case dstk is not really the source of truth and
just reflects the state of an external system that we don't have
any control over. Add also that we're storing sensitive access keys
and folks don't always (though they should) have great S3 security
postures, we don't want to keep any keys to the blob storage kingdom
lying around if we don't need to. Worst case, a user can always
re-create a storage provider later on.

One thing that this PR does not consider is how we want to treat FK
references to objects that users have created against the to-be-deleted
storage provider. An option would be to cascade the deletion and just
nuke everything. We could alternately change the `NOT NULL` constraint
on the FK references and just zero them out for all impacted objects.
Although if we went that route, we'd need to make sure we displayed
a big, scary warning to users telling them that their shit is about
to irrevocably break if they continue with this definitely dangerous
action. And users always read warnings, right?

Ultimately I think the safest bet is probably going to be to soft-delete
things where we:

  1. Set an is_archived bit on the row;
  2. Overwrite or just NULL out the endpoint, region, keys, etc.;
  3. Propagate the archive action to affected objects;
  4. Hide this all behind a big, scary "type delete \<storage provider ID\>
     to continue" confirmation dialog that explains the Very-Bad-But-Not-Catastrophic
     Day you're about to have if you do this without understanding the
     consequences for any registered or deployed models and model versions
