### PR TITLE
Soft-delete storage providers

### DIFF
--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -16,6 +16,7 @@ export const StorageProvider = objectType({
         t.string('owner');
         t.string('dateCreated');
         t.string('dateModified');
+        t.boolean('isArchived');
     },
 });
 
@@ -31,6 +32,7 @@ export class ObjectionStorageProvider extends Model {
     owner!: string;
     dateCreated!: string;
     dateModified!: string;
+    isArchived!: boolean;
 
     static tableName = 'registry.storageProviders';
     static get idColumn() {


### PR DESCRIPTION
Resolves #36

This commit changes the deletion behavior for storage
providers to be a soft-delete/archive action.

We will now, instead of deleting the row, toggle the `is_archived`
boolean and explicitly overwrite the access key ID and the secret
access key for the record. This is also a fully reversible action:
by hitting the same method a second time, it will re-activate the
storage provider, albeit with errors because the required secret
no longer exists and will need to be recreated from the
editStorageProvider mutation. In the SDK and the web frontent, we
can build some reasonable user experiences around this to make
it a seamless unarchive action that calls both GQL methods behind
the scenes for the user.
