### PR TITLE
Add createModel mutation

### DIFF
--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -1,4 +1,5 @@
 export * from './model/model.js';
+export * from './model/modelMutations.js';
 
 export * from './storage-provider/storageProvider.js';
 export * from './storage-provider/storageProviderQueries.js';

--- a/dstk-infra/apollo/src/graphql/model/modelMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model/modelMutations.ts
@@ -1,0 +1,40 @@
+import { extendType, inputObjectType, nonNull } from 'nexus';
+import { MLModel, ObjectionMLModel } from './model.js';
+import { raw } from 'objection';
+
+export const ModelInputType = inputObjectType({
+    name: 'ModelInput',
+    definition(t) {
+        t.nonNull.string('storageProviderId');
+        t.nonNull.string('modelName');
+        t.nonNull.string('description');
+    },
+});
+
+export const CreateModelMutation = extendType({
+    type: 'Mutation',
+    definition(t) {
+        t.field('createModel', {
+            type: MLModel,
+            args: { data: ModelInputType },
+            async resolve(root, args, ctx) {
+                const results = ObjectionMLModel.transaction(async (trx) => {
+                    // TODO: some server-side validation that the supplied
+                    // storage provider ID is a valid record (that the user
+                    // has permission to utilize) is probably needed
+                    const mlModel = await ObjectionMLModel.query(trx)
+                        .insertAndFetch({
+                            storageProviderId: args.data.storageProviderId,
+                            modelName: args.data.modelName,
+                            description: args.data.description,
+                        })
+                        .first();
+
+                    return mlModel;
+                });
+
+                return results;
+            },
+        });
+    },
+});

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -16,6 +16,7 @@ export const StorageProvider = objectType({
         t.string('owner');
         t.string('dateCreated');
         t.string('dateModified');
+        t.boolean('isArchived');
     },
 });
 
@@ -31,6 +32,7 @@ export class ObjectionStorageProvider extends Model {
     owner!: string;
     dateCreated!: string;
     dateModified!: string;
+    isArchived!: boolean;
 
     static tableName = 'registry.storageProviders';
     static get idColumn() {

--- a/dstk-infra/bin/storage
+++ b/dstk-infra/bin/storage
@@ -69,7 +69,7 @@ storage__readiness() {
 storage__upgrade() {
   # Enumerate patches
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd -P)
-  readarray -d '' patches < <(find "${SCRIPT_DIR}/../postgres/patches" -type f -name '*.sql' -print0 | sort)
+  readarray -d '' patches < <(find "${SCRIPT_DIR}/../postgres/patches" -type f -name '*.sql' -print0 | sort -z)
 
   for patch in "${patches[@]}"; do
     base_name=$(basename "${patch}")


### PR DESCRIPTION
Refs #25

This adds a mutation to create a new model in the registry. Note
that models as top-level objects are just basically metadata
and don't represent any actual model object.

One thing that I noticed testing this change is that `ObjectionMLModel`
in `graphql/model/model.ts` implements `StorageProviderId` as a string
(which is accurate wrt the database); however the `MLModel` definition
resolves it to a `StorageProvider` object. In practice, this results
in a null result set being returned when trying to pull back the storage
provider associated with the model:
```json
{
  "data": {
    "createModel": {
      "dateCreated": "1702488888433",
      "dateModified": "1702488888433",
      "description": "model go brrrrrr",
      "isArchived": false,
      "modelId": "ce31013b-9c59-4d9b-90db-43e9ff93c484",
      "modelName": "super awesome mega model",
      "storageProvider": null
    }
  }
}
```

We can do this by extending the `ObjectionMLModel` to include
```typescript
storageProvider: ObjectionStorageProvider
```
and including the relation mapping to resolve this.

...I think. It's been a minute, so I might be getting it wrong, but
regardless, it's a bug I wanted to call out for us to circle back to
sometime later.
