### PR TITLE
Add getModel and listModel queries

### DIFF
--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -1,4 +1,5 @@
 export * from './model/model.js';
+export * from './model/modelQueries.js';
 export * from './model/modelMutations.js';
 
 export * from './storage-provider/storageProvider.js';

--- a/dstk-infra/apollo/src/graphql/model/modelMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model/modelMutations.ts
@@ -1,4 +1,4 @@
-import { extendType, inputObjectType, nonNull } from 'nexus';
+import { extendType, inputObjectType, nonNull, stringArg } from 'nexus';
 import { MLModel, ObjectionMLModel } from './model.js';
 import { raw } from 'objection';
 
@@ -8,13 +8,6 @@ export const ModelInputType = inputObjectType({
         t.nonNull.string('storageProviderId');
         t.nonNull.string('modelName');
         t.nonNull.string('description');
-    },
-});
-
-export const ModelIdInputType = inputObjectType({
-    name: 'ModelIdInput',
-    definition(t) {
-        t.nonNull.string('modelId');
     },
 });
 
@@ -52,13 +45,13 @@ export const EditModelMutation = extendType({
         t.field('editModel', {
             type: MLModel,
             args: {
-                modelId: ModelIdInputType,
+                modelId: nonNull(stringArg()),
                 data: ModelInputType,
             },
             async resolve(root, args, ctx) {
                 const results = ObjectionMLModel.transaction(async (trx) => {
                     const mlModel = await ObjectionMLModel.query(trx).patchAndFetchById(
-                        args.modelId.modelId,
+                        args.modelId,
                         {
                             modelName: args.data.modelName,
                             description: args.data.description,
@@ -81,12 +74,12 @@ export const ArchiveModelMutation = extendType({
         t.field('archiveModel', {
             type: MLModel,
             args: {
-                modelId: ModelIdInputType,
+                modelId: nonNull(stringArg()),
             },
             async resolve(root, args, ctx) {
                 const results = ObjectionMLModel.transaction(async (trx) => {
                     const mlModel = await ObjectionMLModel.query(trx).patchAndFetchById(
-                        args.modelId.modelId,
+                        args.modelId,
                         {
                             isArchived: raw('NOT is_archived'),
                             dateModified: raw('NOW()'),

--- a/dstk-infra/apollo/src/graphql/model/modelQueries.ts
+++ b/dstk-infra/apollo/src/graphql/model/modelQueries.ts
@@ -1,0 +1,31 @@
+import { extendType, stringArg, nonNull } from 'nexus';
+import { MLModel, ObjectionMLModel } from './model.js';
+
+export const ListMLModels = extendType({
+    type: 'Query',
+    definition(t) {
+        t.nonNull.list.field('listModels', {
+            type: MLModel,
+            async resolve(root, args, ctx) {
+                const query = ObjectionMLModel.query();
+                const result = await query.orderBy('dateCreated');
+                return result;
+            },
+        });
+    },
+});
+
+export const GetMLModel = extendType({
+    type: 'Query',
+    definition(t) {
+        t.nonNull.list.field('getModel', {
+            type: MLModel,
+            args: {
+                modelId: nonNull(stringArg()),
+            },
+            async resolve(root, args, ctx) {
+                return await ObjectionMLModel.query().findById(args.modelId);
+            },
+        });
+    },
+});

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -1,4 +1,4 @@
-import { extendType, inputObjectType, nonNull } from 'nexus';
+import { extendType, inputObjectType, nonNull, stringArg } from 'nexus';
 import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
 import { raw } from 'objection';
 
@@ -10,13 +10,6 @@ export const StorageProviderInputType = inputObjectType({
         t.nonNull.string('bucket');
         t.nonNull.string('accessKeyId');
         t.nonNull.string('secretAccessKey');
-    },
-});
-
-export const StorageProviderIdInputType = inputObjectType({
-    name: 'StorageProviderId',
-    definition(t) {
-        t.nonNull.string('providerId');
     },
 });
 
@@ -53,14 +46,14 @@ export const EditStorageProviderMutation = extendType({
         t.field('editStorageProvider', {
             type: StorageProvider,
             args: {
-                providerId: StorageProviderIdInputType,
+                providerId: nonNull(stringArg()),
                 data: StorageProviderInputType,
             },
             async resolve(root, args, ctx) {
                 const results = ObjectionStorageProvider.transaction(async (trx) => {
                     const storageProvider = await ObjectionStorageProvider.query(
                         trx,
-                    ).patchAndFetchById(args.providerId.providerId, {
+                    ).patchAndFetchById(args.providerId, {
                         endpointUrl: args.data.endpointUrl,
                         region: args.data.region,
                         bucket: args.data.bucket,
@@ -84,13 +77,13 @@ export const ArchiveStorageProviderMutation = extendType({
         t.field('archiveStorageProvider', {
             type: StorageProvider,
             args: {
-                providerId: StorageProviderIdInputType,
+                providerId: nonNull(stringArg()),
             },
             async resolve(root, args, ctx) {
                 const results = ObjectionStorageProvider.transaction(async (trx) => {
                     const storageProvider = await ObjectionStorageProvider.query(
                         trx,
-                    ).patchAndFetchById(args.providerId.providerId, {
+                    ).patchAndFetchById(args.providerId, {
                         isArchived: raw('NOT is_archived'),
                         secretAccessKey: '<DELETED>',
                         accessKeyId: '<DELETED>',


### PR DESCRIPTION
Refs #25

This adds new GQL queries to list all models and to
return the details of a single model by its ID. I also
cleaned up some of the ID inputs since there wasn't
any good reason to have a dedicated input type for them
when we could just pass them as inline args to the methods
that need them.
