### PR TITLE
Create Dashboard Layout Component and Navigation Links

### DIFF
--- a/dstk-web/src/components/layout/DashboardLayout.tsx
+++ b/dstk-web/src/components/layout/DashboardLayout.tsx
@@ -1,10 +1,24 @@
 import { Disclosure } from '@headlessui/react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
-const nav = 'Never gonna give you up 🎶';
+import { cn } from '@/lib/cn';
+
+const navigation = [
+    {
+        name: 'Home',
+        href: '/dashboard',
+        icon: Bars3Icon,
+    },
+    {
+        name: 'Model Registry',
+        href: '/models',
+        icon: Bars3Icon,
+    },
+];
 
 export const DashboardLayout = () => {
+    const location = useLocation();
     return (
         <div className='flex flex-col min-h-screen'>
             {/* Navbar */}
@@ -44,7 +58,21 @@ export const DashboardLayout = () => {
 
                         <Disclosure.Panel className='sm:hidden'>
                             <div className='flex flex-col gap-1 px-2 pb-3 pt-2'>
-                                <Disclosure.Button className='text-white'>{nav}</Disclosure.Button>
+                                {navigation.map((navItem) => (
+                                    <Disclosure.Button
+                                        key={navItem.name}
+                                        as='a'
+                                        href={navItem.href}
+                                        className={cn(
+                                            'block rounded-md px-3 py-2 text-base font-medium',
+                                            navItem.href === location.pathname
+                                                ? 'bg-gray-900 text-white'
+                                                : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                                        )}
+                                    >
+                                        {navItem.name}
+                                    </Disclosure.Button>
+                                ))}
                             </div>
                         </Disclosure.Panel>
                     </>
@@ -55,7 +83,7 @@ export const DashboardLayout = () => {
                 {/* Sidebar */}
                 <div className='hidden overflow-x-auto border-r border-gray-900/10 py-4 px-2 sm:px-6 lg:px-8 sm:block sm:w-64 sm:flex-none'>
                     <nav className='flex flex-col'>
-                        <div className='text-sm'>{nav}</div>
+                        <div className='text-sm'>hi</div>
                     </nav>
                 </div>
 

--- a/dstk-web/src/components/layout/DashboardLayout.tsx
+++ b/dstk-web/src/components/layout/DashboardLayout.tsx
@@ -1,9 +1,10 @@
 import { Disclosure } from '@headlessui/react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Outlet } from 'react-router-dom';
 
 const nav = 'Never gonna give you up 🎶';
 
-export const Dashboard = () => {
+export const DashboardLayout = () => {
     return (
         <div className='flex flex-col min-h-screen'>
             {/* Navbar */}
@@ -59,7 +60,9 @@ export const Dashboard = () => {
                 </div>
 
                 {/* Main Content */}
-                <main className='flex flex-grow px-4 py-4 sm:px-6 bg-gray-50'>Content Here</main>
+                <main className='flex flex-grow px-4 py-4 sm:px-6 bg-gray-50'>
+                    <Outlet />
+                </main>
             </div>
         </div>
     );

--- a/dstk-web/src/components/layout/DashboardLayout.tsx
+++ b/dstk-web/src/components/layout/DashboardLayout.tsx
@@ -1,5 +1,5 @@
 import { Disclosure } from '@headlessui/react';
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Bars3Icon, HomeIcon, SquaresPlusIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import { cn } from '@/lib/cn';
@@ -8,24 +8,25 @@ const navigation = [
     {
         name: 'Home',
         href: '/dashboard',
-        icon: Bars3Icon,
+        icon: HomeIcon,
     },
     {
         name: 'Model Registry',
         href: '/models',
-        icon: Bars3Icon,
+        icon: SquaresPlusIcon,
     },
 ];
 
 export const DashboardLayout = () => {
     const location = useLocation();
+
     return (
         <div className='flex flex-col min-h-screen'>
             {/* Navbar */}
             <Disclosure as='header' className='bg-gray-800'>
                 {({ open }) => (
                     <>
-                        <div className='mx-auto max-w-7xl px-2 sm:px-6 lg:px-8'>
+                        <div className='mx-auto max-w-7xl px-2 sm:px-8 lg:px-10'>
                             <div className='relative flex h-16 items-center justify-between'>
                                 <div className='absolute inset-y-0 left-0 flex items-center sm:hidden'>
                                     {/* Mobile menu button*/}
@@ -82,13 +83,38 @@ export const DashboardLayout = () => {
             <div className='flex flex-grow'>
                 {/* Sidebar */}
                 <div className='hidden overflow-x-auto border-r border-gray-900/10 py-4 px-2 sm:px-6 lg:px-8 sm:block sm:w-64 sm:flex-none'>
-                    <nav className='flex flex-col'>
-                        <div className='text-sm'>hi</div>
+                    <nav>
+                        <ul className='flex flex-col gap-1'>
+                            {navigation.map((navItem) => (
+                                <li key={navItem.name}>
+                                    <a
+                                        href={navItem.href}
+                                        className={cn(
+                                            'group flex gap-3 rounded-md p-2 text-sm leading-6 font-semibold',
+                                            navItem.href === location.pathname
+                                                ? 'bg-gray-50 text-gray-800'
+                                                : 'text-gray-600 hover:text-gray-800 hover:bg-gray-50',
+                                        )}
+                                    >
+                                        <navItem.icon
+                                            className={cn(
+                                                'h-6 w-6 shrink-0',
+                                                navItem.href === location.pathname
+                                                    ? 'text-gray-800'
+                                                    : 'text-gray-400 group-hover:text-gray-800',
+                                            )}
+                                            aria-hidden='true'
+                                        />
+                                        {navItem.name}
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
                     </nav>
                 </div>
 
                 {/* Main Content */}
-                <main className='flex flex-grow px-4 py-4 sm:px-6 bg-gray-50'>
+                <main className='flex flex-grow bg-gray-50 px-4 py-4 sm:px-6'>
                     <Outlet />
                 </main>
             </div>

--- a/dstk-web/src/components/layout/index.ts
+++ b/dstk-web/src/components/layout/index.ts
@@ -1,0 +1,1 @@
+export * from './DashboardLayout';

--- a/dstk-web/src/lib/cn.ts
+++ b/dstk-web/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export const cn = (...inputs: ClassValue[]) => {
+    return twMerge(clsx(inputs));
+};

--- a/dstk-web/src/providers/RouterProvider.tsx
+++ b/dstk-web/src/providers/RouterProvider.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider as Router } from 'react-router-dom';
 
-import { Dashboard } from '@/routes/dashboard';
+import { DashboardLayout } from '@/components/layout';
+import { Home, ModelRegistry } from '@/routes';
 
 // TODO: Will modularize this with protected / public routes whenever we get there
 export const RouterProvider = () => {
@@ -10,8 +11,17 @@ export const RouterProvider = () => {
             element: <div>Welcome to dstk!</div>,
         },
         {
-            path: '/dashboard',
-            element: <Dashboard />,
+            element: <DashboardLayout />,
+            children: [
+                {
+                    path: '/dashboard',
+                    element: <Home />,
+                },
+                {
+                    path: '/models',
+                    element: <ModelRegistry />,
+                },
+            ],
         },
     ]);
 

--- a/dstk-web/src/routes/home/index.tsx
+++ b/dstk-web/src/routes/home/index.tsx
@@ -1,0 +1,3 @@
+export const Home = () => {
+    return <div>Hi!</div>;
+};

--- a/dstk-web/src/routes/index.ts
+++ b/dstk-web/src/routes/index.ts
@@ -1,0 +1,2 @@
+export * from './home';
+export * from './model-registry';

--- a/dstk-web/src/routes/model-registry/index.tsx
+++ b/dstk-web/src/routes/model-registry/index.tsx
@@ -1,0 +1,3 @@
+export const ModelRegistry = () => {
+    return <div>Hello from the model registry page!</div>;
+};


### PR DESCRIPTION
- Before starting on the ui for the individual pages, I put the dashboard structure into its own layout component since all of the pages within the dashboard are going to share this element.
- I also added in some navigation links just to show how the navigation works (there are no real pages yet).
- Lastly, added in a className utility function. This just makes it easier to merge conditional styles in tailwind.

As an fyi, I didn't really put any ui elements into their own components since this stuff will only exist on this dashboard layout (plus the the file is only around ~120 lines which isn't too bad). Just wanted to point this out since as we start to build out the actual pages, I'll start putting things into proper components (buttons, cards, etc.)

This is how everything looks now:

### Large View
<img width="1279" alt="image" src="https://github.com/wetherc/dstk/assets/77359138/8fa52590-58d7-4a45-a88a-30928db7eb33">

### Small View
<img width="500" alt="image" src="https://github.com/wetherc/dstk/assets/77359138/5170ffb1-edbb-4a31-93df-3dda162503e0">
