### PR TITLE
Create Breadcrumb Component

### DIFF
--- a/dstk-web/src/components/ui/breadcrumb/BreadcrumbItem.tsx
+++ b/dstk-web/src/components/ui/breadcrumb/BreadcrumbItem.tsx
@@ -1,0 +1,20 @@
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+
+import { cn } from '@/lib/cn';
+
+export type BreadcrumbItemProps = {
+    children: React.ReactNode;
+    href: string;
+} & React.LiHTMLAttributes<HTMLLIElement>;
+
+export const BreadcrumbItem = ({ children, className, href, ...props }: BreadcrumbItemProps) => {
+    return (
+        <li className={cn('group flex items-center gap-4', className)} {...props}>
+            {/* Yeah I CSS like that */}
+            <ChevronRightIcon className='group-first:hidden h-4 w-4 flex-shrink-0 text-gray-400' />
+            <a className='text-sm font-medium text-gray-500 hover:text-gray-700' href={href}>
+                {children}
+            </a>
+        </li>
+    );
+};

--- a/dstk-web/src/components/ui/breadcrumb/Breadcrumbs.tsx
+++ b/dstk-web/src/components/ui/breadcrumb/Breadcrumbs.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/lib/cn';
+
+export type BreadcrumbsProps = {
+    children: React.ReactNode;
+} & React.OlHTMLAttributes<HTMLOListElement>;
+
+export const Breadcrumbs = ({ children, className, ...props }: BreadcrumbsProps) => {
+    return (
+        <nav>
+            <ol className={cn('flex items-center gap-4', className)} {...props}>
+                {children}
+            </ol>
+        </nav>
+    );
+};

--- a/dstk-web/src/components/ui/breadcrumb/index.ts
+++ b/dstk-web/src/components/ui/breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export * from './BreadcrumbItem';
+export * from './Breadcrumbs';

--- a/dstk-web/src/components/ui/index.ts
+++ b/dstk-web/src/components/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './breadcrumb';


### PR DESCRIPTION
Ref #28 

Added components for Breadcrumb navigation. `BreadcrumbItems` are the actual navigation links and `Breadcrumbs` is the list wrapper.
