### PR TITLE
Create Button Component

### DIFF
--- a/dstk-web/src/components/ui/button/Button.tsx
+++ b/dstk-web/src/components/ui/button/Button.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/cn';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const buttonVariants = cva('font-semibold', {
+    variants: {
+        variant: {
+            primary:
+                'bg-indigo-600 text-white hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600',
+            secondary: 'bg-white text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50',
+        },
+        size: {
+            xs: 'rounded px-2 py-1 text-xs',
+            sm: 'rounded px-2 py-1 text-sm',
+            md: 'rounded-md px-2.5 py-1.5 text-sm',
+            lg: 'rounded-md px-3 py-2 text-sm',
+            xl: 'rounded-md px-3.5 py-2.5 text-sm',
+        },
+    },
+    defaultVariants: {
+        variant: 'primary',
+        size: 'md',
+    },
+});
+
+export type ButtonProps = {
+    children: React.ReactNode;
+} & React.ButtonHTMLAttributes<HTMLButtonElement> &
+    VariantProps<typeof buttonVariants>;
+
+export const Button = ({ children, className, size, variant, ...props }: ButtonProps) => {
+    return (
+        <button className={cn(buttonVariants({ size, variant, className }))} {...props}>
+            {children}
+        </button>
+    );
+};

--- a/dstk-web/src/components/ui/button/index.ts
+++ b/dstk-web/src/components/ui/button/index.ts
@@ -1,0 +1,1 @@
+export * from './Button';

--- a/dstk-web/src/components/ui/index.ts
+++ b/dstk-web/src/components/ui/index.ts
@@ -1,1 +1,2 @@
 export * from './breadcrumb';
+export * from './button';


### PR DESCRIPTION
Created Button Component. Props extend normal button attributes, but has two additional prop stylings:

- `variant`: Changes the color of the button
  - `primary`: Indigo
  - `secondary`: Gray
- `size`: Changes the padding and text size within the button
  - Ranges from `xs` to `xl`

<img width="528" alt="image" src="https://github.com/wetherc/dstk/assets/77359138/c3a09a20-4d88-4fe4-9869-1f90580c7722">
