### PR TITLE
Create Model Management UI

### DIFF
--- a/dstk-web/src/components/layout/DashboardLayout.tsx
+++ b/dstk-web/src/components/layout/DashboardLayout.tsx
@@ -28,7 +28,7 @@ export const DashboardLayout = () => {
                     <>
                         <div className='mx-auto max-w-7xl px-2 sm:px-8 lg:px-10'>
                             <div className='relative flex h-16 items-center justify-between'>
-                                <div className='absolute inset-y-0 left-0 flex items-center sm:hidden'>
+                                <div className='absolute inset-y-0 left-0 flex items-center md:hidden'>
                                     {/* Mobile menu button*/}
                                     <Disclosure.Button className='relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white'>
                                         {open ? (
@@ -46,18 +46,18 @@ export const DashboardLayout = () => {
                                 </div>
 
                                 {/* Logo */}
-                                <div className='flex flex-1 items-center justify-center sm:items-stretch sm:justify-start'>
+                                <div className='flex flex-1 items-center justify-center md:items-stretch md:justify-start'>
                                     <span className='text-white'>DSTK Logo</span>
                                 </div>
 
                                 {/* User Menu */}
-                                <div className='absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0'>
+                                <div className='absolute inset-y-0 right-0 flex items-center pr-2 md:static md:inset-auto md:ml-6 md:pr-0'>
                                     <span className='text-white'>User Menu</span>
                                 </div>
                             </div>
                         </div>
 
-                        <Disclosure.Panel className='sm:hidden'>
+                        <Disclosure.Panel className='lg:hidden'>
                             <div className='flex flex-col gap-1 px-2 pb-3 pt-2'>
                                 {navigation.map((navItem) => (
                                     <Disclosure.Button
@@ -82,7 +82,7 @@ export const DashboardLayout = () => {
 
             <div className='flex flex-grow'>
                 {/* Sidebar */}
-                <div className='hidden overflow-x-auto border-r border-gray-900/10 py-4 px-2 sm:px-6 lg:px-8 sm:block sm:w-64 sm:flex-none'>
+                <div className='hidden overflow-x-auto border-r border-gray-900/10 py-4 px-2 md:px-6 lg:px-8 md:block md:w-64 md:flex-none'>
                     <nav>
                         <ul className='flex flex-col gap-1'>
                             {navigation.map((navItem) => (
@@ -114,7 +114,7 @@ export const DashboardLayout = () => {
                 </div>
 
                 {/* Main Content */}
-                <main className='flex flex-grow bg-gray-50 px-4 py-4 sm:px-6'>
+                <main className='flex-grow overflow-hidden bg-gray-50 px-4 py-6 sm:px-8'>
                     <Outlet />
                 </main>
             </div>

--- a/dstk-web/src/components/ui/index.ts
+++ b/dstk-web/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 export * from './breadcrumb';
 export * from './button';
+export * from './status-icon';
 export * from './table';

--- a/dstk-web/src/components/ui/status-icon/StatusIcon.tsx
+++ b/dstk-web/src/components/ui/status-icon/StatusIcon.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/cn';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const statusIconVariants = cva('flex-none rounded-full p-1', {
+    variants: {
+        variant: {
+            success: 'text-green-400 bg-green-400/10',
+            pending: 'text-blue-400 bg-blue-400/10',
+            error: 'text-red-400 bg-red-400/10',
+            archived: 'text-gray-500 bg-gray-100/10',
+        },
+    },
+    defaultVariants: {
+        variant: 'success',
+    },
+});
+
+export type StatusIconProps = VariantProps<typeof statusIconVariants>;
+
+export const StatusIcon = ({ variant }: StatusIconProps) => {
+    return (
+        <div className={cn(statusIconVariants({ variant }))}>
+            <div className='h-2 w-2 rounded-full bg-current' />
+        </div>
+    );
+};

--- a/dstk-web/src/components/ui/status-icon/index.ts
+++ b/dstk-web/src/components/ui/status-icon/index.ts
@@ -1,0 +1,1 @@
+export * from './StatusIcon';

--- a/dstk-web/src/routes/model-registry/index.tsx
+++ b/dstk-web/src/routes/model-registry/index.tsx
@@ -1,3 +1,81 @@
+import {
+    BreadcrumbItem,
+    Breadcrumbs,
+    Button,
+    StatusIcon,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeaderCell,
+    TableRow,
+} from '@/components/ui';
+
 export const ModelRegistry = () => {
-    return <div>Hello from the model registry page!</div>;
+    return (
+        <div className='w-full flex flex-col gap-12'>
+            {/* Page Header */}
+            <header className='flex flex-col gap-4'>
+                <div>
+                    <Breadcrumbs>
+                        <BreadcrumbItem href='/dashboard'>Dashboard</BreadcrumbItem>
+                        <BreadcrumbItem href='/models'>Models</BreadcrumbItem>
+                    </Breadcrumbs>
+                </div>
+                <div className='flex items-center justify-between gap-0'>
+                    <h2 className='text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight'>
+                        Model Registry
+                    </h2>
+                    <Button size='lg'>Create</Button>
+                </div>
+            </header>
+            <Table className='whitespace-nowrap overflow-x-scroll'>
+                <TableHead>
+                    <TableRow>
+                        <TableHeaderCell>Name</TableHeaderCell>
+                        <TableHeaderCell>Total Versions</TableHeaderCell>
+                        <TableHeaderCell>Deployments</TableHeaderCell>
+                        <TableHeaderCell>Created By</TableHeaderCell>
+                        <TableHeaderCell>Last Modified</TableHeaderCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    <TableRow>
+                        <TableCell className='font-medium text-gray-900'>
+                            Housing Market Clustering
+                        </TableCell>
+                        <TableCell>5</TableCell>
+                        <TableCell>
+                            <div className='flex flex-col gap-2'>
+                                <div className='flex items-center gap-2'>
+                                    <StatusIcon variant='success' />3 Active
+                                </div>
+                                <div className='flex items-center gap-2'>
+                                    <StatusIcon variant='pending' />1 Pending
+                                </div>
+                                <div className='flex items-center gap-2'>
+                                    <StatusIcon variant='archived' />1 Archived
+                                </div>
+                            </div>
+                        </TableCell>
+                        <TableCell>Steve O</TableCell>
+                        <TableCell>December 12th, 2023</TableCell>
+                    </TableRow>
+                    <TableRow>
+                        <TableCell className='font-medium text-gray-900'>Employee Churn</TableCell>
+                        <TableCell>3</TableCell>
+                        <TableCell>
+                            <div className='flex flex-col gap-2'>
+                                <div className='flex items-center gap-2'>
+                                    <StatusIcon variant='error' />3 Failed
+                                </div>
+                            </div>
+                        </TableCell>
+                        <TableCell>Michael L</TableCell>
+                        <TableCell>December 10th, 2023</TableCell>
+                    </TableRow>
+                </TableBody>
+            </Table>
+        </div>
+    );
 };


### PR DESCRIPTION
Closes #29 

Added wireframe for Model Management UI. When we actually start getting this data from a server, we'll come back and add in features such as inputs, filtering, pagination, better responsive designs, etc.

Also altered the padding and responsive design for the dashboard layout so that the elements align better with the contents of the children.

Also also, added a status icon component for the table which helps the user visually represent their model health quickly (green - success, red - failure, etc.)

<img width="1024" alt="image" src="https://github.com/wetherc/dstk/assets/77359138/3395e2fe-64a5-4620-b8de-3427bdb87c8f">
