### PR TITLE
Start work on a createModelVersion mutation

### DIFF
--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -2,6 +2,9 @@ export * from './model/model.js';
 export * from './model/modelQueries.js';
 export * from './model/modelMutations.js';
 
+export * from './model-version/modelVersion.js';
+export * from './model-version/modelVersionMutations.js';
+
 export * from './storage-provider/storageProvider.js';
 export * from './storage-provider/storageProviderQueries.js';
 export * from './storage-provider/storageProviderMutations.js';

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
@@ -1,5 +1,5 @@
 import { objectType } from 'nexus';
-import { MLModel, ObjectionMLModel } from '../model/model';
+import { MLModel, ObjectionMLModel } from '../model/model.js';
 import { Model } from 'objection';
 
 export const MLModelVersion = objectType({

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -1,0 +1,61 @@
+import { extendType, inputObjectType, nonNull, stringArg } from 'nexus';
+import { MLModelVersion, ObjectionMLModelVersion } from './modelVersion.js';
+import { raw } from 'objection';
+import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
+
+export const ModelVersionInputType = inputObjectType({
+    name: 'ModelVersionInput',
+    definition(t) {
+        t.nonNull.string('modelId');
+        t.string('description');
+    },
+});
+
+export const CreateModelVersionMutation = extendType({
+    type: 'Mutation',
+    definition(t) {
+        t.field('createModelVersion', {
+            type: MLModelVersion,
+            args: { data: ModelVersionInputType },
+            async resolve(root, args, ctx) {
+                const results = ObjectionMLModelVersion.transaction(async (trx) => {
+                    const modelStorageProvider = await ObjectionStorageProvider.query()
+                        .select(
+                            'registry.storageProviders.endpointUrl',
+                            'registry.storageProviders.region',
+                            'registry.storageProviders.bucket',
+                            'registry.storageProviders.accessKeyId',
+                            'registry.storageProviders.secretAccessKey',
+                        )
+                        .innerJoin(
+                            'registry.models as m',
+                            'registry.storageProviders.providerId',
+                            'm.storageProviderId',
+                        )
+                        .where('m.modelId', args.data.modelId)
+                        .first();
+
+                    console.log(modelStorageProvider);
+
+                    const lastModelVersion = await ObjectionMLModelVersion.query()
+                        .select('numericVersion')
+                        .where('modelId', args.data.modelId)
+                        .orderBy('numericVersion', 'DESC')
+                        .first();
+
+                    const mlModelVersion = await ObjectionMLModelVersion.query(trx)
+                        .insertAndFetch({
+                            modelId: args.data.modelId,
+                            description: args.data.description,
+                            numericVersion: (lastModelVersion?.numericVersion || 0) + 1,
+                        })
+                        .first();
+
+                    return mlModelVersion;
+                });
+
+                return results;
+            },
+        });
+    },
+});

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -32,6 +32,7 @@ export class ObjectionStorageProvider extends Model {
     owner!: string;
     dateCreated!: string;
     dateModified!: string;
+    isFinalized!: boolean;
     isArchived!: boolean;
 
     static tableName = 'registry.storageProviders';
@@ -44,7 +45,7 @@ export class ObjectionStorageProvider extends Model {
             relation: Model.HasManyRelation,
             modelClass: ObjectionMLModel,
             join: {
-                from: 'registry.storageProviders.id',
+                from: 'registry.storageProviders.providerId',
                 to: 'registry.models.storageProviderId',
             },
         },

--- a/dstk-infra/postgres/patches/20231212_registry-models-table.sql
+++ b/dstk-infra/postgres/patches/20231212_registry-models-table.sql
@@ -37,6 +37,7 @@ CREATE TABLE registry.model_versions (
     id               SERIAL  NOT NULL PRIMARY KEY,
     model_version_id UUID    NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
     model_id         UUID    NOT NULL REFERENCES registry.models(model_id),
+    is_finalized     BOOLEAN NOT NULL DEFAULT FALSE,
     is_archived      BOOLEAN NOT NULL DEFAULT FALSE,
     created_by       UUID    REFERENCES dstk_user.user(user_id),
     numeric_version  INTEGER NOT NULL,


### PR DESCRIPTION
NOTE: This API is unstable and is liable to change in breaking
ways.

This begins the work for what we'll need to create and upload
new model versions. Specifically, here I'm just stubbing out
the endpoint to the point that it will create a new database
record for the model version.

As next steps, I will need to bring in the AWS S3 SDK and create
a new presigned URL that the client can use to upload the model
binary to blob storage. When that happens, this will likely get
broken apart into create-, upload-, and finalizeModelVersion
mutations (although really the upload one isn't going to be a
GQL mutation since that's just a client-side POST request for the
multipart upload).

Basically the flow is going to go:

  - User says, "I want to create a new model version"
  - Server says, "Love it, boss. Here's a URL you can use to upload
    all your cool shiz to"
  - User (or really, the UI/SDK/whatever the user is interacting
    with) posts the model binary to the MPU URL and does whatever
    checksum verification they want to make sure that the upload
    succeeded
  - User tells DSTK, "Yep, model version uploaded and is good to go!"
  - profit

I don't think we'll be able to simplify that flow meaningfully
since we (1) don't really want to be abusing Apollo for large binary
uploads, and (2) don't want to just be handing over to the user the
keys to whatever storage provider is configured for use with a given
model. Taking the presigned URL approach lets us keep secrets secure
within DSTK while also giving the end user a convenient way to upload
their blob, with the downside that it adds a couple steps that we need
to string together behind the scenes for folks.

It's also important to note that multipart uploads (which we will want
given the possibly large filesizes of trained models) do require a
`completeMultipartUpload` API call to S3 which sort of goes along
with why I added an `is_finalized` column to the model versions table.
Although separate things, we'd still like to probably offer an escape
hatch for folks if something gets borked partway through an upload and
they need to regen the presigned URL and try again.
