### PR TITLE
Fix Active Styling for Sidebar Links

### DIFF
--- a/dstk-web/src/components/layout/DashboardLayout.tsx
+++ b/dstk-web/src/components/layout/DashboardLayout.tsx
@@ -7,18 +7,22 @@ import { cn } from '@/lib/cn';
 const navigation = [
     {
         name: 'Home',
-        href: '/dashboard',
+        href: '/dashboard/home',
         icon: HomeIcon,
     },
     {
         name: 'Model Registry',
-        href: '/models',
+        href: '/dashboard/models',
         icon: SquaresPlusIcon,
     },
 ];
 
 export const DashboardLayout = () => {
     const location = useLocation();
+
+    const checkSubrouteMatch = (route: string) => {
+        return route.split('/')[2] === location.pathname.split('/')[2];
+    };
 
     return (
         <div className='flex flex-col min-h-screen'>
@@ -66,7 +70,7 @@ export const DashboardLayout = () => {
                                         href={navItem.href}
                                         className={cn(
                                             'block rounded-md px-3 py-2 text-base font-medium',
-                                            navItem.href === location.pathname
+                                            checkSubrouteMatch(navItem.href)
                                                 ? 'bg-gray-900 text-white'
                                                 : 'text-gray-300 hover:bg-gray-700 hover:text-white',
                                         )}
@@ -91,7 +95,7 @@ export const DashboardLayout = () => {
                                         href={navItem.href}
                                         className={cn(
                                             'group flex gap-3 rounded-md p-2 text-sm leading-6 font-semibold',
-                                            navItem.href === location.pathname
+                                            navItem.href.split('/')[2] === location.pathname
                                                 ? 'bg-gray-50 text-gray-800'
                                                 : 'text-gray-600 hover:text-gray-800 hover:bg-gray-50',
                                         )}
@@ -99,7 +103,7 @@ export const DashboardLayout = () => {
                                         <navItem.icon
                                             className={cn(
                                                 'h-6 w-6 shrink-0',
-                                                navItem.href === location.pathname
+                                                checkSubrouteMatch(navItem.href)
                                                     ? 'text-gray-800'
                                                     : 'text-gray-400 group-hover:text-gray-800',
                                             )}

--- a/dstk-web/src/components/layout/DashboardLayout.tsx
+++ b/dstk-web/src/components/layout/DashboardLayout.tsx
@@ -95,7 +95,7 @@ export const DashboardLayout = () => {
                                         href={navItem.href}
                                         className={cn(
                                             'group flex gap-3 rounded-md p-2 text-sm leading-6 font-semibold',
-                                            navItem.href.split('/')[2] === location.pathname
+                                            checkSubrouteMatch(navItem.href)
                                                 ? 'bg-gray-50 text-gray-800'
                                                 : 'text-gray-600 hover:text-gray-800 hover:bg-gray-50',
                                         )}

--- a/dstk-web/src/providers/RouterProvider.tsx
+++ b/dstk-web/src/providers/RouterProvider.tsx
@@ -12,17 +12,18 @@ export const RouterProvider = () => {
         },
         {
             element: <DashboardLayout />,
+            path: '/dashboard',
             children: [
                 {
-                    path: '/dashboard',
+                    path: '/dashboard/home',
                     element: <Home />,
                 },
                 {
-                    path: '/models',
+                    path: '/dashboard/models',
                     element: <ModelRegistry />,
                 },
                 {
-                    path: '/models/:modelId',
+                    path: '/dashboard/models/:modelId',
                     element: <ModelVersion />,
                 },
             ],

--- a/dstk-web/src/routes/model-registry/index.tsx
+++ b/dstk-web/src/routes/model-registry/index.tsx
@@ -21,8 +21,8 @@ export const ModelRegistry = () => {
             <header className='flex flex-col gap-4'>
                 <div>
                     <Breadcrumbs>
-                        <BreadcrumbItem href='/dashboard'>Dashboard</BreadcrumbItem>
-                        <BreadcrumbItem href='/models'>Models</BreadcrumbItem>
+                        <BreadcrumbItem href='/dashboard/home'>Dashboard</BreadcrumbItem>
+                        <BreadcrumbItem href='/dashboard/models'>Models</BreadcrumbItem>
                     </Breadcrumbs>
                 </div>
                 <div className='flex items-center justify-between gap-0'>
@@ -45,7 +45,7 @@ export const ModelRegistry = () => {
                 <TableBody>
                     <TableRow
                         className='hover:bg-gray-50 hover:cursor-pointer'
-                        onClick={() => navigate('/models/1234')}
+                        onClick={() => navigate('/dashboard/models/1234')}
                     >
                         <TableCell className='font-medium text-gray-900'>
                             Housing Market Clustering

--- a/dstk-web/src/routes/model-version/index.tsx
+++ b/dstk-web/src/routes/model-version/index.tsx
@@ -59,9 +59,9 @@ export const ModelVersion = () => {
             <header className='flex flex-col gap-4'>
                 <div>
                     <Breadcrumbs>
-                        <BreadcrumbItem href='/dashboard'>Dashboard</BreadcrumbItem>
-                        <BreadcrumbItem href='/models'>Models</BreadcrumbItem>
-                        <BreadcrumbItem href='/models/1234'>
+                        <BreadcrumbItem href='/dashboard/home'>Dashboard</BreadcrumbItem>
+                        <BreadcrumbItem href='/dashboard/models'>Models</BreadcrumbItem>
+                        <BreadcrumbItem href='/dashboard/models/1234'>
                             Housing Market Clustering
                         </BreadcrumbItem>
                     </Breadcrumbs>


### PR DESCRIPTION
Closes #57 

Changed the routing structure for the dashboard pages. This makes it much easier to check if a child route is active for a parent route because we can just check the equality of the pathname at the third position to the pathname from react router.

Before:
- `/dashboard` => Home
- `/models` => Model Registry
- `/models/some-model-id` => Model Version Page

After:
- `/dashboard/home` => Home
- `/dashboard/models` => Model Registry
- `/dashboard/models/some-model-id` => Model Version Page