### PR TITLE
Add Copy to Clipboard UX to Model Versioning Page

### DIFF
--- a/dstk-web/src/components/ui/index.ts
+++ b/dstk-web/src/components/ui/index.ts
@@ -3,3 +3,4 @@ export * from './breadcrumb';
 export * from './button';
 export * from './status-icon';
 export * from './table';
+export * from './tooltip';

--- a/dstk-web/src/components/ui/tooltip/Tooltip.tsx
+++ b/dstk-web/src/components/ui/tooltip/Tooltip.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/lib/cn';
+
+type TooltipProps = {
+    children: React.ReactNode;
+    isVisible: boolean;
+    message: string;
+};
+
+export const Tooltip = ({ children, isVisible, message }: TooltipProps) => {
+    return (
+        <div className='relative w-max'>
+            {children}
+            <span
+                className={cn(
+                    'pointer-events-none absolute -top-7 left-0 w-max rounded bg-gray-900 px-2 py-1 text-sm font-medium text-gray-50 shadow transition-opacity',
+                    isVisible ? 'opacity-100' : 'opacity-0',
+                )}
+            >
+                {message}
+            </span>
+        </div>
+    );
+};

--- a/dstk-web/src/components/ui/tooltip/index.ts
+++ b/dstk-web/src/components/ui/tooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './Tooltip';

--- a/dstk-web/src/routes/model-version/index.tsx
+++ b/dstk-web/src/routes/model-version/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { ClipboardIcon } from '@heroicons/react/24/outline';
 
 import {
@@ -12,6 +13,7 @@ import {
     TableHeaderCell,
     TableRow,
     type BadgeProps,
+    Tooltip,
 } from '@/components/ui';
 
 const models = [
@@ -53,6 +55,23 @@ const models = [
 ];
 
 export const ModelVersion = () => {
+    const [isTooltipHidden, setIsTooltipHidden] = useState(true);
+    const [copiedVersionId, setCopiedVersionId] = useState('');
+
+    const handleCopy = (modelVersion: string) => {
+        if (isTooltipHidden) {
+            setIsTooltipHidden(false);
+            setCopiedVersionId(modelVersion);
+
+            navigator.clipboard.writeText(modelVersion);
+
+            setTimeout(() => {
+                setIsTooltipHidden(true);
+                setCopiedVersionId('');
+            }, 750);
+        }
+    };
+
     return (
         <div className='w-full flex flex-col gap-12'>
             {/* Page Header */}
@@ -88,12 +107,19 @@ export const ModelVersion = () => {
                         <TableRow key={model.versionId}>
                             <TableCell
                                 className='hover:text-gray-800 hover:cursor-pointer'
-                                onClick={() => console.log('Text to copy:', model.versionId)}
+                                onClick={() => handleCopy(model.versionId)}
                             >
-                                <div className='flex items-center gap-1'>
-                                    <div>{model.versionId.substring(0, 8)}...</div>
-                                    <ClipboardIcon className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer' />
-                                </div>
+                                <Tooltip
+                                    isVisible={
+                                        !isTooltipHidden && model.versionId === copiedVersionId
+                                    }
+                                    message='Copied!'
+                                >
+                                    <div className='flex items-center gap-1'>
+                                        <div>{model.versionId.substring(0, 8)}...</div>
+                                        <ClipboardIcon className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer' />
+                                    </div>
+                                </Tooltip>
                             </TableCell>
                             <TableCell>{model.version}</TableCell>
                             <TableCell>


### PR DESCRIPTION
Edit: Closes #58 

When clicked, a tooltip pops up with the message *Copied!* and then goes away 750ms.