### PR TITLE
Allow completion of multipart upload

### DIFF
--- a/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
@@ -1,6 +1,6 @@
 import { objectType } from 'nexus';
 import { MLModel, ObjectionMLModel } from '../model/model.js';
-import Objection, { Model } from 'objection';
+import { Model } from 'objection';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
 
 export const MLModelVersion = objectType({

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -5,6 +5,7 @@ import {
     CreateMultipartUpload,
     PresignedURL,
     CreatePresignedURLForPart,
+    FinalizeMultipartUpload,
 } from '../../utils/s3-api.js';
 import { ObjectionMLModel } from '../model/model.js';
 
@@ -60,6 +61,24 @@ export const CreateModelVersionMutation = extendType({
     },
 });
 
+export const CompletedPartInputType = inputObjectType({
+    name: 'CompletedPartUploadInput',
+    definition(t) {
+        t.nonNull.string('ETag');
+        t.nonNull.int('PartNumber');
+    },
+});
+
+export const PartsInputType = inputObjectType({
+    name: 'PartsInputType',
+    definition(t) {
+        t.list.field(
+            'Parts', // This is capitalized to conform to the AWS SDK
+            { type: CompletedPartInputType },
+        );
+    },
+});
+
 const PresignMethod = enumType({
     name: 'method',
     members: [
@@ -80,6 +99,9 @@ export const PresignedURLInputType = inputObjectType({
         t.nonNull.string('filename');
         t.string('uploadId');
         t.int('partNumber');
+        t.field('multipartUpload', {
+            type: PartsInputType,
+        });
     },
 });
 
@@ -127,6 +149,19 @@ export const PresignURLForModelVersion = extendType({
                             key: key,
                             partNumber: args.data.partNumber,
                             url: result,
+                        };
+                    } else if (args.data.method === 'finalizeMultipartUpload') {
+                        const result = await FinalizeMultipartUpload(
+                            modelStorageProvider,
+                            key,
+                            args.data.uploadId,
+                            args.data.multipartUpload,
+                        );
+                        mpu_url = {
+                            uploadId: args.data.uploadId,
+                            key: key,
+                            ETag: result.ETag,
+                            url: result.Location,
                         };
                     } else {
                         mpu_url = {};

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -2,10 +2,11 @@ import { extendType, inputObjectType, enumType } from 'nexus';
 import { MLModelVersion, ObjectionMLModelVersion } from './modelVersion.js';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
 import {
+    AbortMultipartUpload,
     CreateMultipartUpload,
-    PresignedURL,
     CreatePresignedURLForPart,
     FinalizeMultipartUpload,
+    PresignedURL,
 } from '../../utils/s3-api.js';
 import { ObjectionMLModel } from '../model/model.js';
 
@@ -163,6 +164,13 @@ export const PresignURLForModelVersion = extendType({
                             ETag: result.ETag,
                             url: result.Location,
                         };
+                    } else if (args.data.method === 'abortMultipartUpload') {
+                        const result = await AbortMultipartUpload(
+                            modelStorageProvider,
+                            key,
+                            args.data.uploadId,
+                        );
+                        mpu_url = {};
                     } else {
                         mpu_url = {};
                     }

--- a/dstk-infra/apollo/src/utils/s3-api.ts
+++ b/dstk-infra/apollo/src/utils/s3-api.ts
@@ -1,9 +1,10 @@
 import { ObjectionStorageProvider } from '../graphql';
 import {
-    S3Client,
-    CreateMultipartUploadCommand,
-    UploadPartCommand,
+    AbortMultipartUploadCommand,
     CompleteMultipartUploadCommand,
+    CreateMultipartUploadCommand,
+    S3Client,
+    UploadPartCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { objectType } from 'nexus';
@@ -96,6 +97,30 @@ export async function FinalizeMultipartUpload(
         Key: key,
         UploadId: uploadId,
         MultipartUpload: multipartUpload,
+    });
+    const response = client.send(command);
+    return response;
+}
+
+export async function AbortMultipartUpload(
+    storageProvider: ObjectionStorageProvider,
+    key: string,
+    uploadId: string,
+) {
+    const client = new S3Client({
+        apiVersion: '2006-03-01',
+        region: storageProvider.region,
+        endpoint: storageProvider.endpointUrl,
+        credentials: {
+            accessKeyId: storageProvider.accessKeyId,
+            secretAccessKey: storageProvider.secretAccessKey,
+        },
+    });
+
+    const command = new AbortMultipartUploadCommand({
+        Bucket: storageProvider.bucket,
+        Key: key,
+        UploadId: uploadId,
     });
     const response = client.send(command);
     return response;

--- a/dstk-infra/apollo/src/utils/s3-api.ts
+++ b/dstk-infra/apollo/src/utils/s3-api.ts
@@ -1,5 +1,10 @@
 import { ObjectionStorageProvider } from '../graphql';
-import { S3Client, CreateMultipartUploadCommand, UploadPartCommand } from '@aws-sdk/client-s3';
+import {
+    S3Client,
+    CreateMultipartUploadCommand,
+    UploadPartCommand,
+    CompleteMultipartUploadCommand,
+} from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { objectType } from 'nexus';
 
@@ -10,6 +15,7 @@ export const PresignedURL = objectType({
         t.string('key');
         t.string('uploadId');
         t.string('partNumber');
+        t.string('ETag');
     },
 });
 
@@ -58,4 +64,39 @@ export async function CreatePresignedURLForPart(
         PartNumber: partNumber,
     });
     return await getSignedUrl(client, command, { expiresIn: 3600 });
+}
+
+export interface CompletedPart {
+    ETag?: string;
+    PartNumber?: number;
+}
+
+export interface CompletedMultipartUpload {
+    Parts?: CompletedPart[];
+}
+
+export async function FinalizeMultipartUpload(
+    storageProvider: ObjectionStorageProvider,
+    key: string,
+    uploadId: string,
+    multipartUpload: CompletedMultipartUpload,
+) {
+    const client = new S3Client({
+        apiVersion: '2006-03-01',
+        region: storageProvider.region,
+        endpoint: storageProvider.endpointUrl,
+        credentials: {
+            accessKeyId: storageProvider.accessKeyId,
+            secretAccessKey: storageProvider.secretAccessKey,
+        },
+    });
+
+    const command = new CompleteMultipartUploadCommand({
+        Bucket: storageProvider.bucket,
+        Key: key,
+        UploadId: uploadId,
+        MultipartUpload: multipartUpload,
+    });
+    const response = client.send(command);
+    return response;
 }


### PR DESCRIPTION
This adds a method to mark a multipart upload as complete
with the upstream storage provider. Note that to do so, you
must supply in the request a list of ETags and their
corresponding part numbers. E.g.,

```json
{
  "Parts": [
    {
      "ETag": "e868e0f4719e394144ef36531ee6824c",
      "PartNumber": 1
    },
    {
      "ETag": "6bb2b12753d66fe86da4998aa33fffb0",
      "PartNumber": 2
    },
    {
      "ETag": "d0a0112e841abec9c9ec83406f0159c8",
      "PartNumber": 3
    }
  ]
}
```

These act as checksums to make sure that the final, reconstituted
file maintains content integrety with respect to the original file
what was uploaded. On success, an ETag will be returned matching
the hash of the reconstituted file.
