### PR TITLE
Error on actions to archived/read-only objects

### DIFF
--- a/dstk-infra/apollo/src/utils/errors.ts
+++ b/dstk-infra/apollo/src/utils/errors.ts
@@ -1,0 +1,23 @@
+type RegistryErrorName =
+    | 'ARCHIVED_STORAGE_ERROR'
+    | 'ARCHIVED_MODEL_ERROR'
+    | 'ARCHIVED_MODEL_VERSION_ERROR'
+    | 'PUBLISHED_MODEL_VERSION_ERROR';
+
+const RegistryErrorMessages = {
+    ARCHIVED_STORAGE_ERROR: 'New model versions cannot be added to an archived storage provider',
+    ARCHIVED_MODEL_ERROR: 'New model versions cannot be added to archived models',
+    ARCHIVED_MODEL_VERSION_ERROR: 'An archived model version cannot be modified',
+    PUBLISHED_MODEL_VERSION_ERROR: 'Published model versions cannot be modified',
+};
+
+export class RegistryOperationError extends Error {
+    name: RegistryErrorName;
+    message: string;
+
+    constructor({ name }: { name: RegistryErrorName }) {
+        super();
+        this.name = name;
+        this.message = RegistryErrorMessages[name];
+    }
+}

--- a/dstk-infra/apollo/src/utils/index.ts
+++ b/dstk-infra/apollo/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './errors.js';
 export * from './s3-api.js';


### PR DESCRIPTION
Resolves #69

This adds in basic error handling when a user attempts to
perform an invalid action (such as creating or editing an
object when one of its logical parents has been archived).
