### PR TITLE
Port Nexus to Pothos

### DIFF
--- a/dstk-infra/apollo/package.json
+++ b/dstk-infra/apollo/package.json
@@ -16,6 +16,8 @@
     "@aws-sdk/s3-request-presigner": "^3.478.0",
     "@aws-sdk/types": "^3.468.0",
     "@aws-sdk/util-format-url": "^3.468.0",
+    "@pothos/core": "^3.41.0",
+    "@pothos/plugin-scope-auth": "^3.20.0",
     "@smithy/hash-node": "^2.0.17",
     "@smithy/protocol-http": "^3.0.11",
     "@smithy/url-parser": "^2.0.15",
@@ -31,6 +33,7 @@
     "ts-node": "^10.9.1"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "@types/node": "^20.4.6",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",

--- a/dstk-infra/apollo/pnpm-lock.yaml
+++ b/dstk-infra/apollo/pnpm-lock.yaml
@@ -20,6 +20,12 @@ dependencies:
   '@aws-sdk/util-format-url':
     specifier: ^3.468.0
     version: 3.468.0
+  '@pothos/core':
+    specifier: ^3.41.0
+    version: 3.41.0(graphql@16.7.1)
+  '@pothos/plugin-scope-auth':
+    specifier: ^3.20.0
+    version: 3.20.0(@pothos/core@3.41.0)(graphql@16.7.1)
   '@smithy/hash-node':
     specifier: ^2.0.17
     version: 2.0.17
@@ -61,6 +67,9 @@ dependencies:
     version: 10.9.1(@types/node@20.4.6)(typescript@5.1.6)
 
 devDependencies:
+  '@types/express':
+    specifier: ^4.17.21
+    version: 4.17.21
   '@types/node':
     specifier: ^20.4.6
     version: 20.4.6
@@ -159,7 +168,7 @@ packages:
       '@apollo/utils.withrequired': 2.0.1
       '@graphql-tools/schema': 9.0.19(graphql@16.7.1)
       '@josephg/resolvable': 1.0.1
-      '@types/express': 4.17.17
+      '@types/express': 4.17.21
       '@types/express-serve-static-core': 4.17.35
       '@types/node-fetch': 2.6.4
       async-retry: 1.3.3
@@ -1070,6 +1079,24 @@ packages:
       fastq: 1.15.0
     dev: true
 
+  /@pothos/core@3.41.0(graphql@16.7.1):
+    resolution: {integrity: sha512-Nb7uPDTXVjdrWqHs5aoD1r6JEdQ9FnJYlf7gv47o1b/bb8rVDAZQaviVvaChal7YQcyFGgCFb0/YNNHLNBEjNw==}
+    peerDependencies:
+      graphql: '>=15.1.0'
+    dependencies:
+      graphql: 16.7.1
+    dev: false
+
+  /@pothos/plugin-scope-auth@3.20.0(@pothos/core@3.41.0)(graphql@16.7.1):
+    resolution: {integrity: sha512-yaAWScp6ob5uG9Ob8YMTTga8DECANx5HW9q/bz4r66RifO/ZNEr1szXl6WpuyhqhGdasvTpzoYakVrYgs8J8wQ==}
+    peerDependencies:
+      '@pothos/core': '*'
+      graphql: '>=15.1.0'
+    dependencies:
+      '@pothos/core': 3.41.0(graphql@16.7.1)
+      graphql: 16.7.1
+    dev: false
+
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
     dev: false
@@ -1587,13 +1614,11 @@ packages:
     dependencies:
       '@types/connect': 3.4.35
       '@types/node': 20.4.6
-    dev: false
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
       '@types/node': 20.4.6
-    dev: false
 
   /@types/eslint-scope@3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
@@ -1620,20 +1645,17 @@ packages:
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
-    dev: false
 
-  /@types/express@4.17.17:
-    resolution: {integrity: sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==}
+  /@types/express@4.17.21:
+    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
     dependencies:
       '@types/body-parser': 1.19.2
       '@types/express-serve-static-core': 4.17.35
       '@types/qs': 6.9.7
       '@types/serve-static': 1.15.2
-    dev: false
 
   /@types/http-errors@2.0.1:
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
-    dev: false
 
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
@@ -1645,11 +1667,9 @@ packages:
 
   /@types/mime@1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
-    dev: false
 
   /@types/mime@3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
-    dev: false
 
   /@types/node-fetch@2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
@@ -1667,11 +1687,9 @@ packages:
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
-    dev: false
 
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
-    dev: false
 
   /@types/react-dom@18.2.7:
     resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
@@ -1700,7 +1718,6 @@ packages:
     dependencies:
       '@types/mime': 1.3.2
       '@types/node': 20.4.6
-    dev: false
 
   /@types/serve-static@1.15.2:
     resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
@@ -1708,7 +1725,6 @@ packages:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
       '@types/node': 20.4.6
-    dev: false
 
   /@typescript-eslint/eslint-plugin@6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.54.0)(typescript@5.1.6):
     resolution: {integrity: sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==}

--- a/dstk-infra/apollo/src/builder.ts
+++ b/dstk-infra/apollo/src/builder.ts
@@ -1,0 +1,15 @@
+import SchemaBuilder from '@pothos/core';
+
+export const builder = new SchemaBuilder<{
+    Context: {
+        user?: {
+            id: number;
+        };
+    };
+    DefaultFieldNullability: true;
+}>({
+    defaultFieldNullability: true,
+});
+
+builder.queryType();
+builder.mutationType();

--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -1,11 +1,15 @@
-export * from './model/model.js';
-export * from './model/modelMutations.js';
-export * from './model/modelQueries.js';
+// export * from './model/model.js';
+// export * from './model/modelMutations.js';
+// export * from './model/modelQueries.js';
 
-export * from './model-version/modelVersion.js';
-export * from './model-version/modelVersionMutations.js';
-export * from './model-version/modelVersionQueries.js';
+// export * from './model-version/modelVersion.js';
+// export * from './model-version/modelVersionMutations.js';
+// export * from './model-version/modelVersionQueries.js';
 
 export * from './storage-provider/storageProvider.js';
 export * from './storage-provider/storageProviderMutations.js';
 export * from './storage-provider/storageProviderQueries.js';
+
+import { builder } from '../builder.js';
+
+export const schema = builder.toSchema();

--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -2,9 +2,9 @@ export * from './model/model.js';
 export * from './model/modelMutations.js';
 export * from './model/modelQueries.js';
 
-// export * from './model-version/modelVersion.js';
-// export * from './model-version/modelVersionMutations.js';
-// export * from './model-version/modelVersionQueries.js';
+export * from './model-version/modelVersion.js';
+export * from './model-version/modelVersionMutations.js';
+export * from './model-version/modelVersionQueries.js';
 
 export * from './storage-provider/storageProvider.js';
 export * from './storage-provider/storageProviderMutations.js';

--- a/dstk-infra/apollo/src/graphql/index.ts
+++ b/dstk-infra/apollo/src/graphql/index.ts
@@ -1,6 +1,6 @@
-// export * from './model/model.js';
-// export * from './model/modelMutations.js';
-// export * from './model/modelQueries.js';
+export * from './model/model.js';
+export * from './model/modelMutations.js';
+export * from './model/modelQueries.js';
 
 // export * from './model-version/modelVersion.js';
 // export * from './model-version/modelVersionMutations.js';

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
@@ -1,27 +1,32 @@
-import { objectType } from 'nexus';
+import { builder } from '../../builder.js';
 import { MLModel, ObjectionMLModel } from '../model/model.js';
 import { Model } from 'objection';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
 
-export const MLModelVersion = objectType({
-    name: 'MLModelVersion',
-    definition(t) {
-        t.id('modelVersionId');
-        t.field('modelId', {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const MLModelVersion = builder.objectRef<any>('MLModelVersion').implement({
+    fields: (t) => ({
+        modelVersionId: t.exposeID('modelVersionId'),
+
+        modelId: t.field({
             type: MLModel,
+
             async resolve(root: ObjectionMLModelVersion, _args, _ctx) {
-                ObjectionMLModel.query().findById(root.modelId).first();
+                const mlModel = (await ObjectionMLModel.query()
+                    .findById(root.modelId)
+                    .first()) as typeof MLModel.$inferType;
+                return mlModel;
             },
-        });
-        t.boolean('isArchived');
-        t.boolean('isFinalized');
-        t.string('createdBy'); // TODO: Resolve actual user object
-        t.int('numericVersion');
-        t.string('description');
-        // TODO: Custom Scalar Type for JSON Object: t.something('metadata')
-        t.string('dateCreated');
-        t.string('s3Prefix');
-    },
+        }),
+
+        isArchived: t.exposeBoolean('isArchived'),
+        isFinalized: t.exposeBoolean('isFinalized'),
+        createdBy: t.exposeString('createdBy'),
+        numericVersion: t.exposeInt('numericVersion'),
+        description: t.exposeString('description'),
+        dateCreated: t.exposeString('dateCreated'),
+        s3Prefix: t.exposeString('s3Prefix'),
+    }),
 });
 
 export class ObjectionMLModelVersion extends Model {
@@ -30,9 +35,9 @@ export class ObjectionMLModelVersion extends Model {
     isArchived!: boolean;
     createdBy!: string;
     numericVersion!: number;
-    description: string;
+    description?: string;
     isFinalized!: boolean;
-    s3Prefix: string;
+    s3Prefix?: string;
     // TODO: metadata: something
     dateCreated!: string;
 

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -11,11 +11,53 @@ import {
 } from '../../utils/s3-api.js';
 import { raw } from 'objection';
 import { builder } from '../../builder.js';
+import { resolve } from 'path';
 
 export const ModelVersionInputType = builder.inputType('ModelVersionInputType', {
     fields: (t) => ({
         modelId: t.string({ required: true }),
         description: t.string(),
+    }),
+});
+
+export const CompletedPartInputType = builder.inputType('CompletedPartInputType', {
+    fields: (t) => ({
+        ETag: t.string({ required: true }),
+        PartNumber: t.int({ required: true }),
+    }),
+});
+
+export const PartsInputType = builder.inputType('PartsInputType', {
+    fields: (t) => ({
+        Parts: t.field({
+            required: true,
+            type: [CompletedPartInputType],
+        }),
+    }),
+});
+
+export const PresignMethod = builder.enumType('PresignMethod', {
+    values: [
+        'createMultipartUpload',
+        'uploadPart',
+        'finalizeMultipartUpload',
+        'abortMultipartUpload',
+    ] as const,
+});
+
+export const PresignedURLInputType = builder.inputType('PresignedURLInputType', {
+    fields: (t) => ({
+        modelVersionId: t.string({ required: true }),
+        method: t.field({
+            required: true,
+            type: PresignMethod,
+        }),
+        filename: t.string(),
+        uploadId: t.string(),
+        partNumber: t.int(),
+        multipartUpload: t.field({
+            type: PartsInputType,
+        }),
     }),
 });
 
@@ -109,134 +151,99 @@ builder.mutationFields((t) => ({
             return results;
         },
     }),
+    presignURL: t.field({
+        type: PresignedURL,
+        args: {
+            data: t.arg({ type: PresignedURLInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const modelStorageProvider = (await ObjectionMLModelVersion.relatedQuery(
+                'storageProvider',
+            )
+                .for(args.data.modelVersionId)
+                .first()) as ObjectionStorageProvider;
+            if (modelStorageProvider.isArchived === true) {
+                throw new RegistryOperationError({ name: 'ARCHIVED_STORAGE_ERROR' });
+            }
+
+            const parentModel = (await ObjectionMLModelVersion.relatedQuery('model')
+                .for(args.data.modelVersionId)
+                .first()) as ObjectionMLModel;
+            if (parentModel.isArchived === true) {
+                throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
+            }
+
+            const modelVersion = (await ObjectionMLModelVersion.query()
+                .findById(args.data.modelVersionId)
+                .first()) as ObjectionMLModelVersion;
+            if (modelVersion.isArchived === true) {
+                throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_VERSION_ERROR' });
+            } else if (modelVersion.isFinalized === true) {
+                throw new RegistryOperationError({ name: 'PUBLISHED_MODEL_VERSION_ERROR' });
+            }
+
+            let mpu_url;
+            const key = `${modelVersion.s3Prefix}/${args.data.filename}`;
+
+            if (args.data.method === 'createMultipartUpload') {
+                const result = await CreateMultipartUpload(modelStorageProvider, key);
+
+                mpu_url = {
+                    uploadId: result.UploadId,
+                    key: result.Key,
+                };
+            }
+
+            if (!args.data.uploadId) {
+                throw new RegistryOperationError({ name: 'MISSING_UPLOAD_ID_ERROR' });
+            }
+            if (!args.data.partNumber) {
+                throw new RegistryOperationError({ name: 'MISSING_PART_NUM_ERROR' });
+            }
+            if (args.data.method === 'uploadPart') {
+                const result = await CreatePresignedURLForPart(
+                    modelStorageProvider,
+                    key,
+                    args.data.uploadId,
+                    args.data.partNumber,
+                );
+
+                mpu_url = {
+                    uploadId: args.data.uploadId,
+                    key: key,
+                    partNumber: args.data.partNumber,
+                    url: result,
+                };
+            } else if (args.data.method === 'abortMultipartUpload') {
+                const result = await AbortMultipartUpload(
+                    modelStorageProvider,
+                    key,
+                    args.data.uploadId,
+                );
+            }
+
+            if (!args.data.multipartUpload) {
+                throw new RegistryOperationError({ name: 'MULTIPART_FINALIZATION_ERROR' });
+            }
+            if (args.data.method === 'finalizeMultipartUpload') {
+                const result = await FinalizeMultipartUpload(
+                    modelStorageProvider,
+                    key,
+                    args.data.uploadId,
+                    args.data.multipartUpload,
+                );
+                mpu_url = {
+                    uploadId: args.data.uploadId,
+                    key: key,
+                    ETag: result.ETag,
+                    url: result.Location,
+                };
+                mpu_url = {};
+            } else {
+                mpu_url = {};
+            }
+
+            return mpu_url as typeof PresignedURL.$inferType;
+        },
+    }),
 }));
-
-// export const CompletedPartInputType = inputObjectType({
-//     name: 'CompletedPartUploadInput',
-//     definition(t) {
-//         t.nonNull.string('ETag');
-//         t.nonNull.int('PartNumber');
-//     },
-// });
-
-// export const PartsInputType = inputObjectType({
-//     name: 'PartsInputType',
-//     definition(t) {
-//         t.list.field(
-//             'Parts', // This is capitalized to conform to the AWS SDK
-//             { type: CompletedPartInputType },
-//         );
-//     },
-// });
-
-// const PresignMethod = enumType({
-//     name: 'method',
-//     members: [
-//         'createMultipartUpload',
-//         'uploadPart',
-//         'finalizeMultipartUpload',
-//         'abortMultipartUpload',
-//     ],
-// });
-
-// export const PresignedURLInputType = inputObjectType({
-//     name: 'PresignedURLInput',
-//     definition(t) {
-//         t.nonNull.string('modelVersionId');
-//         t.nonNull.field('method', {
-//             type: PresignMethod,
-//         });
-//         t.nonNull.string('filename');
-//         t.string('uploadId');
-//         t.int('partNumber');
-//         t.field('multipartUpload', {
-//             type: PartsInputType,
-//         });
-//     },
-// });
-
-// export const PresignURLForModelVersion = extendType({
-//     type: 'Mutation',
-//     definition(t) {
-//         t.field('presignURL', {
-//             type: PresignedURL,
-//             args: { data: PresignedURLInputType },
-//             async resolve(root, args, ctx) {
-//                 const modelStorageProvider = (await ObjectionMLModelVersion.relatedQuery(
-//                     'storageProvider',
-//                 )
-//                     .for(args.data.modelVersionId)
-//                     .first()) as ObjectionStorageProvider;
-//                 if (modelStorageProvider.isArchived === true) {
-//                     throw new RegistryOperationError({ name: 'ARCHIVED_STORAGE_ERROR' });
-//                 }
-
-//                 const parentModel = (await ObjectionMLModelVersion.relatedQuery('model')
-//                     .for(args.data.modelVersionId)
-//                     .first()) as ObjectionMLModel;
-//                 if (parentModel.isArchived === true) {
-//                     throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
-//                 }
-
-//                 const modelVersion = await ObjectionMLModelVersion.query()
-//                     .where('modelVersionId', args.data.modelVersionId)
-//                     .first();
-//                 if (modelVersion.isArchived === true) {
-//                     throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_VERSION_ERROR' });
-//                 } else if (modelVersion.isFinalized === true) {
-//                     throw new RegistryOperationError({ name: 'PUBLISHED_MODEL_VERSION_ERROR' });
-//                 }
-
-//                 let mpu_url;
-//                 const key = `${modelVersion.s3Prefix}/${args.data.filename}`;
-
-//                 if (args.data.method === 'createMultipartUpload') {
-//                     const result = await CreateMultipartUpload(modelStorageProvider, key);
-
-//                     mpu_url = {
-//                         uploadId: result.UploadId,
-//                         key: result.Key,
-//                     };
-//                 } else if (args.data.method === 'uploadPart') {
-//                     const result = await CreatePresignedURLForPart(
-//                         modelStorageProvider,
-//                         key,
-//                         args.data.uploadId,
-//                         args.data.partNumber,
-//                     );
-
-//                     mpu_url = {
-//                         uploadId: args.data.uploadId,
-//                         key: key,
-//                         partNumber: args.data.partNumber,
-//                         url: result,
-//                     };
-//                 } else if (args.data.method === 'finalizeMultipartUpload') {
-//                     const result = await FinalizeMultipartUpload(
-//                         modelStorageProvider,
-//                         key,
-//                         args.data.uploadId,
-//                         args.data.multipartUpload,
-//                     );
-//                     mpu_url = {
-//                         uploadId: args.data.uploadId,
-//                         key: key,
-//                         ETag: result.ETag,
-//                         url: result.Location,
-//                     };
-//                 } else if (args.data.method === 'abortMultipartUpload') {
-//                     const result = await AbortMultipartUpload(
-//                         modelStorageProvider,
-//                         key,
-//                         args.data.uploadId,
-//                     );
-//                     mpu_url = {};
-//                 } else {
-//                     mpu_url = {};
-//                 }
-
-//                 return mpu_url;
-//             },
-//         });
-//     },
-// });

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -1,4 +1,3 @@
-import { extendType, inputObjectType, enumType, nonNull, stringArg } from 'nexus';
 import { MLModelVersion, ObjectionMLModelVersion } from './modelVersion.js';
 import { ObjectionMLModel } from '../model/model.js';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
@@ -11,238 +10,233 @@ import {
     PresignedURL,
 } from '../../utils/s3-api.js';
 import { raw } from 'objection';
+import { builder } from '../../builder.js';
 
-export const ModelVersionInputType = inputObjectType({
-    name: 'ModelVersionInput',
-    definition(t) {
-        t.nonNull.string('modelId');
-        t.string('description');
-    },
+export const ModelVersionInputType = builder.inputType('ModelVersionInputType', {
+    fields: (t) => ({
+        modelId: t.string({ required: true }),
+        description: t.string(),
+    }),
 });
 
-export const CreateModelVersionMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('createModelVersion', {
-            type: MLModelVersion,
-            args: { data: ModelVersionInputType },
-            async resolve(root, args, ctx) {
-                const results = ObjectionMLModelVersion.transaction(async (trx) => {
-                    const parentModel = await ObjectionMLModel.query().findById(args.data.modelId);
-                    if (parentModel.isArchived === true) {
-                        throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
-                    }
-                    const lastModelVersion = await ObjectionMLModelVersion.query()
-                        .select('numericVersion')
-                        .where('modelId', args.data.modelId)
-                        .orderBy('numericVersion', 'DESC')
-                        .first();
-                    const incrementedVersion = (lastModelVersion?.numericVersion || 0) + 1;
-
-                    // TODO: We will need to parameterize the team subpath once
-                    // user auth stuff gets set up; just hardcoding it to a dummy
-                    // location for now
-                    const s3_prefix = `teams/DEFAULT/models/${args.data.modelId}/versions/${incrementedVersion}`;
-
-                    const mlModelVersion = await ObjectionMLModelVersion.query(trx)
-                        .insertAndFetch({
-                            modelId: args.data.modelId,
-                            description: args.data.description,
-                            numericVersion: incrementedVersion,
-                            s3Prefix: s3_prefix,
-                        })
-                        .first();
-
-                    return mlModelVersion;
-                });
-
-                return results;
-            },
-        });
-    },
-});
-
-export const CompletedPartInputType = inputObjectType({
-    name: 'CompletedPartUploadInput',
-    definition(t) {
-        t.nonNull.string('ETag');
-        t.nonNull.int('PartNumber');
-    },
-});
-
-export const PartsInputType = inputObjectType({
-    name: 'PartsInputType',
-    definition(t) {
-        t.list.field(
-            'Parts', // This is capitalized to conform to the AWS SDK
-            { type: CompletedPartInputType },
-        );
-    },
-});
-
-const PresignMethod = enumType({
-    name: 'method',
-    members: [
-        'createMultipartUpload',
-        'uploadPart',
-        'finalizeMultipartUpload',
-        'abortMultipartUpload',
-    ],
-});
-
-export const PresignedURLInputType = inputObjectType({
-    name: 'PresignedURLInput',
-    definition(t) {
-        t.nonNull.string('modelVersionId');
-        t.nonNull.field('method', {
-            type: PresignMethod,
-        });
-        t.nonNull.string('filename');
-        t.string('uploadId');
-        t.int('partNumber');
-        t.field('multipartUpload', {
-            type: PartsInputType,
-        });
-    },
-});
-
-export const PresignURLForModelVersion = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('presignURL', {
-            type: PresignedURL,
-            args: { data: PresignedURLInputType },
-            async resolve(root, args, ctx) {
-                const modelStorageProvider = (await ObjectionMLModelVersion.relatedQuery(
-                    'storageProvider',
-                )
-                    .for(args.data.modelVersionId)
-                    .first()) as ObjectionStorageProvider;
-                if (modelStorageProvider.isArchived === true) {
-                    throw new RegistryOperationError({ name: 'ARCHIVED_STORAGE_ERROR' });
-                }
-
-                const parentModel = (await ObjectionMLModelVersion.relatedQuery('model')
-                    .for(args.data.modelVersionId)
+builder.mutationFields((t) => ({
+    createModelVersion: t.field({
+        type: MLModelVersion,
+        args: {
+            data: t.arg({ type: ModelVersionInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionMLModelVersion.transaction(async (trx) => {
+                const parentModel = (await ObjectionMLModel.query()
+                    .where('modelId', args.data.modelId)
                     .first()) as ObjectionMLModel;
                 if (parentModel.isArchived === true) {
                     throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
                 }
-
-                const modelVersion = await ObjectionMLModelVersion.query()
-                    .where('modelVersionId', args.data.modelVersionId)
+                const lastModelVersion = await ObjectionMLModelVersion.query()
+                    .select('numericVersion')
+                    .where('modelId', args.data.modelId)
+                    .orderBy('numericVersion', 'DESC')
                     .first();
-                if (modelVersion.isArchived === true) {
-                    throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_VERSION_ERROR' });
-                } else if (modelVersion.isFinalized === true) {
-                    throw new RegistryOperationError({ name: 'PUBLISHED_MODEL_VERSION_ERROR' });
-                }
+                const incrementedVersion = (lastModelVersion?.numericVersion || 0) + 1;
 
-                let mpu_url;
-                const key = `${modelVersion.s3Prefix}/${args.data.filename}`;
+                // TODO: We will need to parameterize the team subpath once
+                // user auth stuff gets set up; just hardcoding it to a dummy
+                // location for now
+                const s3_prefix = `teams/DEFAULT/models/${args.data.modelId}/versions/${incrementedVersion}`;
 
-                if (args.data.method === 'createMultipartUpload') {
-                    const result = await CreateMultipartUpload(modelStorageProvider, key);
+                const mlModelVersion = await ObjectionMLModelVersion.query(trx)
+                    .insertAndFetch({
+                        modelId: args.data.modelId,
+                        description: args.data?.description || raw('NULL'),
+                        numericVersion: incrementedVersion,
+                        s3Prefix: s3_prefix,
+                    })
+                    .first();
 
-                    mpu_url = {
-                        uploadId: result.UploadId,
-                        key: result.Key,
-                    };
-                } else if (args.data.method === 'uploadPart') {
-                    const result = await CreatePresignedURLForPart(
-                        modelStorageProvider,
-                        key,
-                        args.data.uploadId,
-                        args.data.partNumber,
-                    );
+                return mlModelVersion as typeof MLModelVersion.$inferType;
+            });
 
-                    mpu_url = {
-                        uploadId: args.data.uploadId,
-                        key: key,
-                        partNumber: args.data.partNumber,
-                        url: result,
-                    };
-                } else if (args.data.method === 'finalizeMultipartUpload') {
-                    const result = await FinalizeMultipartUpload(
-                        modelStorageProvider,
-                        key,
-                        args.data.uploadId,
-                        args.data.multipartUpload,
-                    );
-                    mpu_url = {
-                        uploadId: args.data.uploadId,
-                        key: key,
-                        ETag: result.ETag,
-                        url: result.Location,
-                    };
-                } else if (args.data.method === 'abortMultipartUpload') {
-                    const result = await AbortMultipartUpload(
-                        modelStorageProvider,
-                        key,
-                        args.data.uploadId,
-                    );
-                    mpu_url = {};
-                } else {
-                    mpu_url = {};
-                }
-
-                return mpu_url;
-            },
-        });
-    },
-});
-
-export const PublishModelVersionMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('publishModelVersion', {
-            type: MLModelVersion,
-            args: { modelVersionId: nonNull(stringArg()) },
-            async resolve(root, args, ctx) {
-                const results = ObjectionMLModelVersion.transaction(async (trx) => {
-                    const mlModelVersion = await ObjectionMLModelVersion.query(
-                        trx,
-                    ).updateAndFetchById(args.modelVersionId, {
+            return results;
+        },
+    }),
+    publishModelVersion: t.field({
+        type: MLModelVersion,
+        args: {
+            modelVersionId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionMLModelVersion.transaction(async (trx) => {
+                const mlModelVersion = await ObjectionMLModelVersion.query(trx).updateAndFetchById(
+                    args.modelVersionId,
+                    {
                         isFinalized: true,
-                    });
+                    },
+                );
 
-                    // since we're wrapping everything in a transaction, throwing
-                    // will cause a rollback
-                    if (mlModelVersion.isArchived === true) {
-                        throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_VERSION_ERROR' });
-                    }
+                // since we're wrapping everything in a transaction, throwing
+                // will cause a rollback
+                if (mlModelVersion.isArchived === true) {
+                    throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_VERSION_ERROR' });
+                }
 
-                    return mlModelVersion;
-                });
+                return mlModelVersion as typeof MLModelVersion.$inferType;
+            });
 
-                return results;
-            },
-        });
-    },
-});
-
-export const ArchiveModelVersionMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('archiveModelVersion', {
-            type: MLModelVersion,
-            args: { modelVersionId: nonNull(stringArg()) },
-            async resolve(root, args, ctx) {
-                const results = ObjectionMLModelVersion.transaction(async (trx) => {
-                    // Intentionally don't throw an error here on archived storage
-                    // providers or models. It's not unreasonable to want to mark old
-                    // assets as archived if a parent object goes bye-bye
-                    const mlModelVersion = await ObjectionMLModelVersion.query(
-                        trx,
-                    ).updateAndFetchById(args.modelVersionId, {
+            return results;
+        },
+    }),
+    archiveModelVersion: t.field({
+        type: MLModelVersion,
+        args: {
+            modelVersionId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionMLModelVersion.transaction(async (trx) => {
+                // Intentionally don't throw an error here on archived storage
+                // providers or models. It's not unreasonable to want to mark old
+                // assets as archived if a parent object goes bye-bye
+                const mlModelVersion = await ObjectionMLModelVersion.query(trx).updateAndFetchById(
+                    args.modelVersionId,
+                    {
                         isArchived: raw('NOT is_archived'),
-                    });
+                    },
+                );
 
-                    return mlModelVersion;
-                });
+                return mlModelVersion as typeof MLModelVersion.$inferType;
+            });
 
-                return results;
-            },
-        });
-    },
-});
+            return results;
+        },
+    }),
+}));
+
+// export const CompletedPartInputType = inputObjectType({
+//     name: 'CompletedPartUploadInput',
+//     definition(t) {
+//         t.nonNull.string('ETag');
+//         t.nonNull.int('PartNumber');
+//     },
+// });
+
+// export const PartsInputType = inputObjectType({
+//     name: 'PartsInputType',
+//     definition(t) {
+//         t.list.field(
+//             'Parts', // This is capitalized to conform to the AWS SDK
+//             { type: CompletedPartInputType },
+//         );
+//     },
+// });
+
+// const PresignMethod = enumType({
+//     name: 'method',
+//     members: [
+//         'createMultipartUpload',
+//         'uploadPart',
+//         'finalizeMultipartUpload',
+//         'abortMultipartUpload',
+//     ],
+// });
+
+// export const PresignedURLInputType = inputObjectType({
+//     name: 'PresignedURLInput',
+//     definition(t) {
+//         t.nonNull.string('modelVersionId');
+//         t.nonNull.field('method', {
+//             type: PresignMethod,
+//         });
+//         t.nonNull.string('filename');
+//         t.string('uploadId');
+//         t.int('partNumber');
+//         t.field('multipartUpload', {
+//             type: PartsInputType,
+//         });
+//     },
+// });
+
+// export const PresignURLForModelVersion = extendType({
+//     type: 'Mutation',
+//     definition(t) {
+//         t.field('presignURL', {
+//             type: PresignedURL,
+//             args: { data: PresignedURLInputType },
+//             async resolve(root, args, ctx) {
+//                 const modelStorageProvider = (await ObjectionMLModelVersion.relatedQuery(
+//                     'storageProvider',
+//                 )
+//                     .for(args.data.modelVersionId)
+//                     .first()) as ObjectionStorageProvider;
+//                 if (modelStorageProvider.isArchived === true) {
+//                     throw new RegistryOperationError({ name: 'ARCHIVED_STORAGE_ERROR' });
+//                 }
+
+//                 const parentModel = (await ObjectionMLModelVersion.relatedQuery('model')
+//                     .for(args.data.modelVersionId)
+//                     .first()) as ObjectionMLModel;
+//                 if (parentModel.isArchived === true) {
+//                     throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
+//                 }
+
+//                 const modelVersion = await ObjectionMLModelVersion.query()
+//                     .where('modelVersionId', args.data.modelVersionId)
+//                     .first();
+//                 if (modelVersion.isArchived === true) {
+//                     throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_VERSION_ERROR' });
+//                 } else if (modelVersion.isFinalized === true) {
+//                     throw new RegistryOperationError({ name: 'PUBLISHED_MODEL_VERSION_ERROR' });
+//                 }
+
+//                 let mpu_url;
+//                 const key = `${modelVersion.s3Prefix}/${args.data.filename}`;
+
+//                 if (args.data.method === 'createMultipartUpload') {
+//                     const result = await CreateMultipartUpload(modelStorageProvider, key);
+
+//                     mpu_url = {
+//                         uploadId: result.UploadId,
+//                         key: result.Key,
+//                     };
+//                 } else if (args.data.method === 'uploadPart') {
+//                     const result = await CreatePresignedURLForPart(
+//                         modelStorageProvider,
+//                         key,
+//                         args.data.uploadId,
+//                         args.data.partNumber,
+//                     );
+
+//                     mpu_url = {
+//                         uploadId: args.data.uploadId,
+//                         key: key,
+//                         partNumber: args.data.partNumber,
+//                         url: result,
+//                     };
+//                 } else if (args.data.method === 'finalizeMultipartUpload') {
+//                     const result = await FinalizeMultipartUpload(
+//                         modelStorageProvider,
+//                         key,
+//                         args.data.uploadId,
+//                         args.data.multipartUpload,
+//                     );
+//                     mpu_url = {
+//                         uploadId: args.data.uploadId,
+//                         key: key,
+//                         ETag: result.ETag,
+//                         url: result.Location,
+//                     };
+//                 } else if (args.data.method === 'abortMultipartUpload') {
+//                     const result = await AbortMultipartUpload(
+//                         modelStorageProvider,
+//                         key,
+//                         args.data.uploadId,
+//                     );
+//                     mpu_url = {};
+//                 } else {
+//                     mpu_url = {};
+//                 }
+
+//                 return mpu_url;
+//             },
+//         });
+//     },
+// });

--- a/dstk-infra/apollo/src/graphql/model-version/modelVersionQueries.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersionQueries.ts
@@ -1,18 +1,17 @@
-import { extendType, stringArg, nonNull } from 'nexus';
 import { MLModelVersion, ObjectionMLModelVersion } from './modelVersion.js';
+import { builder } from '../../builder.js';
 
-export const ListModelVersions = extendType({
-    type: 'Query',
-    definition(t) {
-        t.nonNull.list.field('listModelVersions', {
-            type: MLModelVersion,
-            args: { modelId: nonNull(stringArg()) },
-            async resolve(root, args, ctx) {
-                const result = await ObjectionMLModelVersion.query()
-                    .where('modelId', args.modelId)
-                    .orderBy('numericVersion', 'ASC');
-                return result;
-            },
-        });
-    },
-});
+builder.queryFields((t) => ({
+    listMLModelVersions: t.field({
+        type: [MLModelVersion],
+        args: {
+            modelId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const mlModelVersions = await ObjectionMLModelVersion.query()
+                .where('modelId', args.modelId)
+                .orderBy('numericVersion', 'ASC');
+            return mlModelVersions;
+        },
+    }),
+}));

--- a/dstk-infra/apollo/src/graphql/model/model.ts
+++ b/dstk-infra/apollo/src/graphql/model/model.ts
@@ -1,7 +1,7 @@
 import { builder } from '../../builder.js';
 import { Model } from 'objection';
 import { StorageProvider, ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
-// import { ObjectionMLModelVersion } from '../model-version/modelVersion.js';
+import { ObjectionMLModelVersion } from '../model-version/modelVersion.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const MLModel = builder.objectRef<any>('MLModel').implement({
@@ -53,13 +53,13 @@ export class ObjectionMLModel extends Model {
                 to: 'registry.storageProviders.providerId',
             },
         },
-        // modelVersions: {
-        //     relation: Model.HasManyRelation,
-        //     modelClass: ObjectionMLModelVersion,
-        //     join: {
-        //         from: 'registry.models.modelId',
-        //         to: 'registry.modelVersions.modelId',
-        //     },
-        // },
+        modelVersions: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionMLModelVersion,
+            join: {
+                from: 'registry.models.modelId',
+                to: 'registry.modelVersions.modelId',
+            },
+        },
     });
 }

--- a/dstk-infra/apollo/src/graphql/model/modelMutations.ts
+++ b/dstk-infra/apollo/src/graphql/model/modelMutations.ts
@@ -1,110 +1,96 @@
-import { extendType, inputObjectType, nonNull, stringArg } from 'nexus';
 import { MLModel, ObjectionMLModel } from './model.js';
 import { raw } from 'objection';
 import { RegistryOperationError } from '../../utils/errors.js';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
+import { builder } from '../../builder.js';
 
-export const ModelInputType = inputObjectType({
-    name: 'ModelInput',
-    definition(t) {
-        t.nonNull.string('storageProviderId');
-        t.nonNull.string('modelName');
-        t.nonNull.string('description');
-    },
+export const ModelInputType = builder.inputType('ModelInput', {
+    fields: (t) => ({
+        storageProviderId: t.string({ required: true }),
+        modelName: t.string({ required: true }),
+        description: t.string({ required: true }),
+    }),
 });
 
-export const CreateModelMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('createModel', {
-            type: MLModel,
-            args: { data: ModelInputType },
-            async resolve(root, args, ctx) {
-                const results = ObjectionMLModel.transaction(async (trx) => {
-                    // TODO: some server-side validation that the supplied
-                    // storage provider ID is a valid record (that the user
-                    // has permission to utilize) is probably needed
-                    const mlModel = await ObjectionMLModel.query(trx)
-                        .insertAndFetch({
-                            storageProviderId: args.data.storageProviderId,
-                            modelName: args.data.modelName,
-                            description: args.data.description,
-                        })
-                        .first();
+builder.mutationFields((t) => ({
+    createModel: t.field({
+        type: MLModel,
+        args: {
+            data: t.arg({ type: ModelInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionMLModel.transaction(async (trx) => {
+                const storageProvider = (await ObjectionStorageProvider.query().findById(
+                    args.data.storageProviderId,
+                )) as ObjectionStorageProvider;
+                if (storageProvider.isArchived === true) {
+                    throw new RegistryOperationError({ name: 'ARCHIVED_STORAGE_ERROR' });
+                }
 
-                    return mlModel;
+                // TODO: some server-side validation that the supplied
+                // storage provider ID is a valid record (that the user
+                // has permission to utilize) is probably needed
+                const mlModel = await ObjectionMLModel.query(trx)
+                    .insertAndFetch({
+                        storageProviderId: args.data.storageProviderId,
+                        modelName: args.data.modelName,
+                        description: args.data.description,
+                    })
+                    .first();
+
+                return mlModel as typeof MLModel.$inferType;
+            });
+            return results;
+        },
+    }),
+    editModel: t.field({
+        type: MLModel,
+        args: {
+            modelId: t.arg.string({ required: true }),
+            data: t.arg({ type: ModelInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionMLModel.transaction(async (trx) => {
+                const storageProvider = (await ObjectionMLModel.relatedQuery('storageProvider')
+                    .for(args.modelId)
+                    .first()) as ObjectionStorageProvider;
+                if (storageProvider.isArchived === true) {
+                    throw new RegistryOperationError({ name: 'ARCHIVED_STORAGE_ERROR' });
+                }
+
+                const mlModel = await ObjectionMLModel.query(trx).patchAndFetchById(args.modelId, {
+                    modelName: args.data.modelName,
+                    description: args.data.description,
+                    dateModified: raw('NOW()'),
                 });
+                if (mlModel.isArchived === true) {
+                    throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
+                }
 
-                return results;
-            },
-        });
-    },
-});
+                return mlModel as typeof MLModel.$inferType;
+            });
 
-export const EditModelMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('editModel', {
-            type: MLModel,
-            args: {
-                modelId: nonNull(stringArg()),
-                data: ModelInputType,
-            },
-            async resolve(root, args, ctx) {
-                const results = ObjectionMLModel.transaction(async (trx) => {
-                    const storageProvider = (await ObjectionMLModel.relatedQuery('storageProvider')
-                        .for(args.modelId)
-                        .first()) as ObjectionStorageProvider;
-                    if (storageProvider.isArchived === true) {
-                        throw new RegistryOperationError({ name: 'ARCHIVED_STORAGE_ERROR' });
-                    }
-
-                    const mlModel = await ObjectionMLModel.query(trx).patchAndFetchById(
-                        args.modelId,
-                        {
-                            modelName: args.data.modelName,
-                            description: args.data.description,
-                            dateModified: raw('NOW()'),
-                        },
-                    );
-                    if (mlModel.isArchived === true) {
-                        throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
-                    }
-
-                    return mlModel;
+            return results;
+        },
+    }),
+    archiveModel: t.field({
+        type: MLModel,
+        args: {
+            modelId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionMLModel.transaction(async (trx) => {
+                // Intentionally don't throw an error here on archived storage
+                // providers. It's not unreasonable to want to mark old assets
+                // as archived if their parent blob storage goes bye-bye
+                const mlModel = await ObjectionMLModel.query(trx).patchAndFetchById(args.modelId, {
+                    isArchived: raw('NOT is_archived'),
+                    dateModified: raw('NOW()'),
                 });
+                return mlModel as typeof MLModel.$inferType;
+            });
 
-                return results;
-            },
-        });
-    },
-});
-
-export const ArchiveModelMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('archiveModel', {
-            type: MLModel,
-            args: {
-                modelId: nonNull(stringArg()),
-            },
-            async resolve(root, args, ctx) {
-                const results = ObjectionMLModel.transaction(async (trx) => {
-                    // Intentionally don't throw an error here on archived storage
-                    // providers. It's not unreasonable to want to mark old assets
-                    // as archived if their parent blob storage goes bye-bye
-                    const mlModel = await ObjectionMLModel.query(trx).patchAndFetchById(
-                        args.modelId,
-                        {
-                            isArchived: raw('NOT is_archived'),
-                            dateModified: raw('NOW()'),
-                        },
-                    );
-                    return mlModel;
-                });
-
-                return results;
-            },
-        });
-    },
-});
+            return results;
+        },
+    }),
+}));

--- a/dstk-infra/apollo/src/graphql/model/modelQueries.ts
+++ b/dstk-infra/apollo/src/graphql/model/modelQueries.ts
@@ -1,31 +1,24 @@
-import { extendType, stringArg, nonNull } from 'nexus';
 import { MLModel, ObjectionMLModel } from './model.js';
+import { builder } from '../../builder.js';
 
-export const ListMLModels = extendType({
-    type: 'Query',
-    definition(t) {
-        t.nonNull.list.field('listModels', {
-            type: MLModel,
-            async resolve(root, args, ctx) {
-                const query = ObjectionMLModel.query();
-                const result = await query.orderBy('dateCreated');
-                return result;
-            },
-        });
-    },
-});
-
-export const GetMLModel = extendType({
-    type: 'Query',
-    definition(t) {
-        t.nonNull.list.field('getModel', {
-            type: MLModel,
-            args: {
-                modelId: nonNull(stringArg()),
-            },
-            async resolve(root, args, ctx) {
-                return await ObjectionMLModel.query().findById(args.modelId);
-            },
-        });
-    },
-});
+builder.queryFields((t) => ({
+    listMLModels: t.field({
+        type: [MLModel],
+        async resolve(root, args, ctx) {
+            const mlModel = await ObjectionMLModel.query().orderBy('dateCreated');
+            return mlModel;
+        },
+    }),
+    getMLModel: t.field({
+        type: MLModel,
+        args: {
+            modelId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const mlModel = (await ObjectionMLModel.query().findById(
+                args.modelId,
+            )) as typeof MLModel.$inferType;
+            return mlModel;
+        },
+    }),
+}));

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -1,6 +1,6 @@
 import { builder } from '../../builder.js';
 import { Model } from 'objection';
-import { ObjectionMLModel } from '../model/model.js';
+// import { ObjectionMLModel } from '../model/model.js';
 import Security from '../../utils/encryption.js';
 
 const EncryptoMatic = new Security();
@@ -48,14 +48,14 @@ export class ObjectionStorageProvider extends Model {
         return 'providerId';
     }
 
-    static relationMappings = () => ({
-        models: {
-            relation: Model.HasManyRelation,
-            modelClass: ObjectionMLModel,
-            join: {
-                from: 'registry.storageProviders.providerId',
-                to: 'registry.models.storageProviderId',
-            },
-        },
-    });
+    // static relationMappings = () => ({
+    //     models: {
+    //         relation: Model.HasManyRelation,
+    //         modelClass: ObjectionMLModel,
+    //         join: {
+    //             from: 'registry.storageProviders.providerId',
+    //             to: 'registry.models.storageProviderId',
+    //         },
+    //     },
+    // });
 }

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -1,11 +1,11 @@
 import { builder } from '../../builder.js';
 import { Model } from 'objection';
-// import { ObjectionMLModel } from '../model/model.js';
+import { ObjectionMLModel } from '../model/model.js';
 import Security from '../../utils/encryption.js';
 
 const EncryptoMatic = new Security();
 
-/* eslint-disable  @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const StorageProvider = builder.objectRef<any>('StorageProvider').implement({
     fields: (t) => ({
         providerId: t.exposeID('providerId'),
@@ -27,7 +27,6 @@ export const StorageProvider = builder.objectRef<any>('StorageProvider').impleme
         isArchived: t.exposeBoolean('isArchived'),
     }),
 });
-/* eslint-enable  @typescript-eslint/no-explicit-any */
 
 export class ObjectionStorageProvider extends Model {
     id!: string;
@@ -48,14 +47,14 @@ export class ObjectionStorageProvider extends Model {
         return 'providerId';
     }
 
-    // static relationMappings = () => ({
-    //     models: {
-    //         relation: Model.HasManyRelation,
-    //         modelClass: ObjectionMLModel,
-    //         join: {
-    //             from: 'registry.storageProviders.providerId',
-    //             to: 'registry.models.storageProviderId',
-    //         },
-    //     },
-    // });
+    static relationMappings = () => ({
+        models: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionMLModel,
+            join: {
+                from: 'registry.storageProviders.providerId',
+                to: 'registry.models.storageProviderId',
+            },
+        },
+    });
 }

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -1,30 +1,33 @@
-import { objectType } from 'nexus';
+import { builder } from '../../builder.js';
 import { Model } from 'objection';
 import { ObjectionMLModel } from '../model/model.js';
 import Security from '../../utils/encryption.js';
 
 const EncryptoMatic = new Security();
 
-export const StorageProvider = objectType({
-    name: 'StorageProvider',
-    definition(t) {
-        t.id('providerId');
-        t.string('endpointUrl');
-        t.string('region');
-        t.string('bucket');
-        t.string('accessKeyId', {
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+export const StorageProvider = builder.objectRef<any>('StorageProvider').implement({
+    fields: (t) => ({
+        providerId: t.exposeID('providerId'),
+        endpointUrl: t.exposeString('endpointUrl'),
+        region: t.exposeString('region'),
+        bucket: t.exposeString('bucket'),
+
+        accessKeyId: t.string({
             resolve(root) {
                 return EncryptoMatic.decrypt(root.accessKeyId);
             },
-        });
-        t.string('createdBy'); // TODO: resolve actual user object
-        t.string('modifiedBy');
-        t.string('owner');
-        t.string('dateCreated');
-        t.string('dateModified');
-        t.boolean('isArchived');
-    },
+        }),
+
+        createdBy: t.exposeString('createdBy'),
+        modifiedBy: t.exposeString('modifiedBy'),
+        owner: t.exposeString('owner'),
+        dateCreated: t.exposeString('dateCreated'),
+        dateModified: t.exposeString('dateModified'),
+        isArchived: t.exposeBoolean('isArchived'),
+    }),
 });
+/* eslint-enable  @typescript-eslint/no-explicit-any */
 
 export class ObjectionStorageProvider extends Model {
     id!: string;

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -18,7 +18,6 @@ export const StorageProviderInputType = builder.inputType('StorageProviderInput'
 builder.mutationFields((t) => ({
     createStorageProvider: t.field({
         type: StorageProvider,
-        nullable: true,
         args: {
             data: t.arg({ type: StorageProviderInputType, required: true }),
         },
@@ -44,7 +43,6 @@ builder.mutationFields((t) => ({
     }),
     editStorageProvider: t.field({
         type: StorageProvider,
-        nullable: true,
         args: {
             providerId: t.arg.string({ required: true }),
             data: t.arg({ type: StorageProviderInputType, required: true }),
@@ -73,7 +71,6 @@ builder.mutationFields((t) => ({
     }),
     archiveStorageProvider: t.field({
         type: StorageProvider,
-        nullable: true,
         args: {
             providerId: t.arg.string({ required: true }),
         },

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -5,15 +5,14 @@ import { raw } from 'objection';
 
 const EncryptoMatic = new Security();
 
-export const StorageProviderInputType = inputObjectType({
-    name: 'StorageProviderInput',
-    definition(t) {
-        t.nonNull.string('endpointUrl');
-        t.nonNull.string('region');
-        t.nonNull.string('bucket');
-        t.nonNull.string('accessKeyId');
-        t.nonNull.string('secretAccessKey');
-    },
+export const StorageProviderInputType = builder.inputType('StorageProviderInput', {
+    fields: (t) => ({
+        endpointUrl: t.string(),
+        region: t.string(),
+        bucket: t.string(),
+        accessKeyId: t.string(),
+        secretAccessKey: t.string(),
+    }),
 });
 
 export const CreateStorageProviderMutation = extendType({

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -1,111 +1,98 @@
-import { extendType, inputObjectType, nonNull, stringArg } from 'nexus';
 import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
 import Security from '../../utils/encryption.js';
 import { raw } from 'objection';
+import { builder } from '../../builder.js';
 
 const EncryptoMatic = new Security();
 
 export const StorageProviderInputType = builder.inputType('StorageProviderInput', {
     fields: (t) => ({
-        endpointUrl: t.string(),
-        region: t.string(),
-        bucket: t.string(),
-        accessKeyId: t.string(),
-        secretAccessKey: t.string(),
+        endpointUrl: t.string({ required: true }),
+        region: t.string({ required: true }),
+        bucket: t.string({ required: true }),
+        accessKeyId: t.string({ required: true }),
+        secretAccessKey: t.string({ required: true }),
     }),
 });
 
-export const CreateStorageProviderMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('createStorageProvider', {
-            type: StorageProvider,
-            args: { data: StorageProviderInputType },
-            async resolve(root, args, ctx) {
-                const results = ObjectionStorageProvider.transaction(async (trx) => {
-                    const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
-                    const encryptedSecretAccessKey = EncryptoMatic.encrypt(
-                        args.data.secretAccessKey,
-                    );
+builder.mutationFields((t) => ({
+    createStorageProvider: t.field({
+        type: StorageProvider,
+        nullable: true,
+        args: {
+            data: t.arg({ type: StorageProviderInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionStorageProvider.transaction(async (trx) => {
+                const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
+                const encryptedSecretAccessKey = EncryptoMatic.encrypt(args.data.secretAccessKey);
 
-                    const storageProvider = await ObjectionStorageProvider.query(trx)
-                        .insertAndFetch({
-                            endpointUrl: args.data.endpointUrl,
-                            region: args.data.region,
-                            bucket: args.data.bucket,
-                            accessKeyId: encryptedAccessKeyId,
-                            secretAccessKey: encryptedSecretAccessKey,
-                        })
-                        .first();
-                    return storageProvider;
-                });
+                const storageProvider = await ObjectionStorageProvider.query(trx)
+                    .insertAndFetch({
+                        endpointUrl: args.data.endpointUrl,
+                        region: args.data.region,
+                        bucket: args.data.bucket,
+                        accessKeyId: encryptedAccessKeyId,
+                        secretAccessKey: encryptedSecretAccessKey,
+                    })
+                    .first();
+                return storageProvider as typeof StorageProvider.$inferType;
+            });
 
-                return results;
-            },
-        });
-    },
-});
+            return results;
+        },
+    }),
+    editStorageProvider: t.field({
+        type: StorageProvider,
+        nullable: true,
+        args: {
+            providerId: t.arg.string({ required: true }),
+            data: t.arg({ type: StorageProviderInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionStorageProvider.transaction(async (trx) => {
+                const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
+                const encryptedSecretAccessKey = EncryptoMatic.encrypt(args.data.secretAccessKey);
 
-export const EditStorageProviderMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('editStorageProvider', {
-            type: StorageProvider,
-            args: {
-                providerId: nonNull(stringArg()),
-                data: StorageProviderInputType,
-            },
-            async resolve(root, args, ctx) {
-                const results = ObjectionStorageProvider.transaction(async (trx) => {
-                    const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
-                    const encryptedSecretAccessKey = EncryptoMatic.encrypt(
-                        args.data.secretAccessKey,
-                    );
-
-                    const storageProvider = await ObjectionStorageProvider.query(
-                        trx,
-                    ).patchAndFetchById(args.providerId, {
+                const storageProvider = await ObjectionStorageProvider.query(trx).patchAndFetchById(
+                    args.providerId,
+                    {
                         endpointUrl: args.data.endpointUrl,
                         region: args.data.region,
                         bucket: args.data.bucket,
                         accessKeyId: encryptedAccessKeyId,
                         secretAccessKey: encryptedSecretAccessKey,
                         dateModified: raw('NOW()'),
-                    });
+                    },
+                );
+                return storageProvider as typeof StorageProvider.$inferType;
+            });
 
-                    return storageProvider;
-                });
-
-                return results;
-            },
-        });
-    },
-});
-
-export const ArchiveStorageProviderMutation = extendType({
-    type: 'Mutation',
-    definition(t) {
-        t.field('archiveStorageProvider', {
-            type: StorageProvider,
-            args: {
-                providerId: nonNull(stringArg()),
-            },
-            async resolve(root, args, ctx) {
-                const results = ObjectionStorageProvider.transaction(async (trx) => {
-                    const storageProvider = await ObjectionStorageProvider.query(
-                        trx,
-                    ).patchAndFetchById(args.providerId, {
+            return results;
+        },
+    }),
+    archiveStorageProvider: t.field({
+        type: StorageProvider,
+        nullable: true,
+        args: {
+            providerId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionStorageProvider.transaction(async (trx) => {
+                const storageProvider = await ObjectionStorageProvider.query(trx).patchAndFetchById(
+                    args.providerId,
+                    {
                         isArchived: raw('NOT is_archived'),
                         secretAccessKey: EncryptoMatic.encrypt('<DELETED>'),
                         accessKeyId: EncryptoMatic.encrypt('<DELETED>'),
                         dateModified: raw('NOW()'),
-                    });
+                    },
+                );
 
-                    return storageProvider;
-                });
+                return storageProvider as typeof StorageProvider.$inferType;
+            });
 
-                return results;
-            },
-        });
-    },
-});
+            return results;
+        },
+    }),
+}));

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -1,34 +1,24 @@
 import { extendType, stringArg, nonNull } from 'nexus';
 import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
+import { builder } from '../../builder.js';
 
-export const ListStorageProviders = extendType({
-    type: 'Query',
-    definition(t) {
-        t.nonNull.list.field('listStorageProviders', {
-            type: StorageProvider,
-            async resolve(root, args, ctx) {
-                const storageProvider = await ObjectionStorageProvider.query().orderBy(
-                    'dateCreated',
-                );
-
-                return storageProvider;
-            },
-        });
-    },
-});
-
-export const GetStorageProvider = extendType({
-    type: 'Query',
-    definition(t) {
-        t.nonNull.list.field('getStorageProvider', {
-            type: StorageProvider,
-            args: {
-                id: nonNull(stringArg()),
-            },
-            async resolve(root, args, ctx) {
-                const storageProvider = await ObjectionStorageProvider.query().findById(args.id);
-                return storageProvider;
-            },
-        });
-    },
-});
+builder.queryFields((t) => ({
+    listStorageProviders: t.field({
+        type: [StorageProvider],
+        async resolve(root, args, ctx) {
+            const storageProvider = await ObjectionStorageProvider.query().orderBy('dateCreated');
+            return storageProvider;
+        },
+    }),
+    getStorageProvider: t.field({
+        type: [StorageProvider],
+        nullable: true,
+        args: {
+            id: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const storageProvider = await ObjectionStorageProvider.query().findById(args.id);
+            return storageProvider;
+        },
+    }),
+}));

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -11,13 +11,12 @@ builder.queryFields((t) => ({
     }),
     getStorageProvider: t.field({
         type: StorageProvider,
-        nullable: true,
         args: {
-            id: t.arg.string({ required: true }),
+            storageProviderId: t.arg.string({ required: true }),
         },
         async resolve(root, args, ctx) {
             const storageProvider = (await ObjectionStorageProvider.query().findById(
-                args.id,
+                args.storageProviderId,
             )) as typeof StorageProvider.$inferType;
             return storageProvider;
         },

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -1,4 +1,3 @@
-import { extendType, stringArg, nonNull } from 'nexus';
 import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
 import { builder } from '../../builder.js';
 
@@ -11,13 +10,15 @@ builder.queryFields((t) => ({
         },
     }),
     getStorageProvider: t.field({
-        type: [StorageProvider],
+        type: StorageProvider,
         nullable: true,
         args: {
             id: t.arg.string({ required: true }),
         },
         async resolve(root, args, ctx) {
-            const storageProvider = await ObjectionStorageProvider.query().findById(args.id);
+            const storageProvider = (await ObjectionStorageProvider.query().findById(
+                args.id,
+            )) as typeof StorageProvider.$inferType;
             return storageProvider;
         },
     }),

--- a/dstk-infra/apollo/src/index.ts
+++ b/dstk-infra/apollo/src/index.ts
@@ -4,7 +4,7 @@ import { startStandaloneServer } from '@apollo/server/standalone';
 import { Model } from 'objection';
 import Knex from 'knex';
 import { knexConfig } from './knexfile.js';
-import { schema } from './graphql';
+import { schema } from './graphql/index.js';
 
 const knex = Knex(knexConfig.development);
 Model.knex(knex);

--- a/dstk-infra/apollo/src/index.ts
+++ b/dstk-infra/apollo/src/index.ts
@@ -1,37 +1,13 @@
-import { makeSchema } from 'nexus';
 import { Request } from 'express';
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { Model } from 'objection';
 import Knex from 'knex';
 import { knexConfig } from './knexfile.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import * as types from './graphql/index.js';
+import { schema } from './graphql';
 
 const knex = Knex(knexConfig.development);
 Model.knex(knex);
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const schema = makeSchema({
-    types,
-    outputs: {
-        schema: path.join(__dirname, '../schema.graphql'),
-        typegen: path.join(__dirname, 'typegen.ts'),
-    },
-    // sourceTypes: {
-    //   modules: [
-    //     {
-    //       module: path.join(__dirname, 'typeDefs.js'),
-    //       alias: 't',
-    //     },
-    //   ],
-    // },
-    contextType: {
-        module: path.join(__dirname, 'context.js'),
-        export: 'Context',
-    },
-});
 
 const context = async ({ req }: { req: Request }) => {
     // simple auth check on every request

--- a/dstk-infra/apollo/src/utils/encryption.ts
+++ b/dstk-infra/apollo/src/utils/encryption.ts
@@ -14,51 +14,42 @@ export default class Security {
     // process.env.CRYPTO_KEY should be a 32 BYTE key
     key = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 
-    encrypt(plaintext: string) {
-        try {
-            const iv = crypto.randomBytes(12);
-            const assocData = crypto.randomBytes(16);
-            const cipher = crypto.createCipheriv('chacha20-poly1305', this.key, iv, {
-                authTagLength: 16,
-            });
+    encrypt(plaintext: string): string {
+        const iv = crypto.randomBytes(12);
+        const assocData = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv('chacha20-poly1305', this.key, iv, {
+            authTagLength: 16,
+        });
 
-            cipher.setAAD(assocData, { plaintextLength: Buffer.byteLength(plaintext) });
+        cipher.setAAD(assocData, { plaintextLength: Buffer.byteLength(plaintext) });
 
-            const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
-            const tag = cipher.getAuthTag();
+        const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+        const tag = cipher.getAuthTag();
 
-            return (
-                iv.toString(this.encoding) +
-                assocData.toString(this.encoding) +
-                encrypted.toString(this.encoding) +
-                tag.toString(this.encoding)
-            );
-        } catch (e) {
-            console.error(e);
-        }
+        return (
+            iv.toString(this.encoding) +
+            assocData.toString(this.encoding) +
+            encrypted.toString(this.encoding) +
+            tag.toString(this.encoding)
+        );
     }
 
-    decrypt(cipherText: string) {
+    decrypt(cipherText: string): string {
         const { encryptedDataString, ivString, assocDataString, tagString } =
             splitEncryptedText(cipherText);
+        const iv = Buffer.from(ivString, this.encoding);
+        const encryptedText = Buffer.from(encryptedDataString, this.encoding);
+        const tag = Buffer.from(tagString, this.encoding);
 
-        try {
-            const iv = Buffer.from(ivString, this.encoding);
-            const encryptedText = Buffer.from(encryptedDataString, this.encoding);
-            const tag = Buffer.from(tagString, this.encoding);
+        const decipher = crypto.createDecipheriv('chacha20-poly1305', this.key, iv, {
+            authTagLength: 16,
+        });
+        decipher.setAAD(Buffer.from(assocDataString, this.encoding), {
+            plaintextLength: encryptedDataString.length,
+        });
+        decipher.setAuthTag(Buffer.from(tag));
 
-            const decipher = crypto.createDecipheriv('chacha20-poly1305', this.key, iv, {
-                authTagLength: 16,
-            });
-            decipher.setAAD(Buffer.from(assocDataString, this.encoding), {
-                plaintextLength: encryptedDataString.length,
-            });
-            decipher.setAuthTag(Buffer.from(tag));
-
-            const decrypted = decipher.update(encryptedText);
-            return Buffer.concat([decrypted, decipher.final()]).toString();
-        } catch (e) {
-            console.error(e);
-        }
+        const decrypted = decipher.update(encryptedText);
+        return Buffer.concat([decrypted, decipher.final()]).toString();
     }
 }

--- a/dstk-infra/apollo/src/utils/errors.ts
+++ b/dstk-infra/apollo/src/utils/errors.ts
@@ -2,13 +2,20 @@ type RegistryErrorName =
     | 'ARCHIVED_STORAGE_ERROR'
     | 'ARCHIVED_MODEL_ERROR'
     | 'ARCHIVED_MODEL_VERSION_ERROR'
-    | 'PUBLISHED_MODEL_VERSION_ERROR';
+    | 'PUBLISHED_MODEL_VERSION_ERROR'
+    | 'MISSING_UPLOAD_ID_ERROR'
+    | 'MISSING_PART_NUM_ERROR'
+    | 'MULTIPART_FINALIZATION_ERROR';
 
 const RegistryErrorMessages = {
     ARCHIVED_STORAGE_ERROR: 'New model versions cannot be added to an archived storage provider',
     ARCHIVED_MODEL_ERROR: 'New model versions cannot be added to archived models',
     ARCHIVED_MODEL_VERSION_ERROR: 'An archived model version cannot be modified',
     PUBLISHED_MODEL_VERSION_ERROR: 'Published model versions cannot be modified',
+    MISSING_UPLOAD_ID_ERROR: 'An Upload ID must be supplied for this operation',
+    MISSING_PART_NUM_ERROR: 'A Part Number must be supuplied for this operation',
+    MULTIPART_FINALIZATION_ERROR:
+        'Uploaded parts and their ETags must be supplied to finalize a MPU',
 };
 
 export class RegistryOperationError extends Error {

--- a/dstk-infra/apollo/src/utils/s3-api.ts
+++ b/dstk-infra/apollo/src/utils/s3-api.ts
@@ -12,7 +12,7 @@ import { builder } from '../builder.js';
 
 const EncryptoMatic = new Security();
 
-/* eslint-disable  @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const PresignedURL = builder.objectRef<any>('PresignedURL').implement({
     fields: (t) => ({
         url: t.exposeString('url'),
@@ -22,7 +22,6 @@ export const PresignedURL = builder.objectRef<any>('PresignedURL').implement({
         ETag: t.exposeString('ETag'),
     }),
 });
-/* eslint-enable  @typescript-eslint/no-explicit-any */
 
 export async function CreateMultipartUpload(
     storageProvider: ObjectionStorageProvider,

--- a/dstk-infra/apollo/src/utils/s3-api.ts
+++ b/dstk-infra/apollo/src/utils/s3-api.ts
@@ -7,21 +7,22 @@ import {
     UploadPartCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { objectType } from 'nexus';
 import Security from './encryption.js';
+import { builder } from '../builder.js';
 
 const EncryptoMatic = new Security();
 
-export const PresignedURL = objectType({
-    name: 'PresignedURL',
-    definition(t) {
-        t.string('url');
-        t.string('key');
-        t.string('uploadId');
-        t.string('partNumber');
-        t.string('ETag');
-    },
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+export const PresignedURL = builder.objectRef<any>('PresignedURL').implement({
+    fields: (t) => ({
+        url: t.exposeString('url'),
+        key: t.exposeString('key'),
+        uploadId: t.exposeString('uploadId'),
+        partNumber: t.exposeString('partNumber'),
+        ETag: t.exposeString('ETag'),
+    }),
 });
+/* eslint-enable  @typescript-eslint/no-explicit-any */
 
 export async function CreateMultipartUpload(
     storageProvider: ObjectionStorageProvider,

--- a/dstk-infra/apollo/tsconfig.json
+++ b/dstk-infra/apollo/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "ESNext",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "types": ["node"]
+    "types": ["node"],
+    "strict": true
   }
 }


### PR DESCRIPTION
This migrates off of Nexus and onto Pothos for
our GraphQL schema builder. Although probably not
strictly necessary, Nexus hasn't been committed
to in 9 months, and its author has already indicated
he would like to merge Nexus into Pothos at some
point since both take similar approaches to the
same problem.

Largely, there's really not much different between
the two besides slightly different boilerplate
here and there. I need to finish testing all of
the methods and make sure I didn't subtly break
anything, but at a first glance nothing is totally
on fire after converting this all over.
