### PR TITLE
Add in Pothos Generic Types

### DIFF
--- a/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
+++ b/dstk-infra/apollo/src/graphql/model-version/modelVersion.ts
@@ -3,10 +3,14 @@ import { MLModel, ObjectionMLModel } from '../model/model.js';
 import { Model } from 'objection';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const MLModelVersion = builder.objectRef<any>('MLModelVersion').implement({
+export const MLModelVersion = builder.objectRef<ObjectionMLModelVersion>('MLModelVersion').implement({
     fields: (t) => ({
-        modelVersionId: t.exposeID('modelVersionId'),
+        modelVersionId: t.field({
+            type: 'ID',
+            resolve(root: ObjectionMLModelVersion, _args, _ctx) {
+                return root.$modelClass.idColumn[0];
+            },
+        }),
 
         modelId: t.field({
             type: MLModel,

--- a/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/dstk-infra/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -5,10 +5,14 @@ import Security from '../../utils/encryption.js';
 
 const EncryptoMatic = new Security();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const StorageProvider = builder.objectRef<any>('StorageProvider').implement({
+export const StorageProvider = builder.objectRef<ObjectionStorageProvider>('StorageProvider').implement({
     fields: (t) => ({
-        providerId: t.exposeID('providerId'),
+        providerId: t.field({
+            type: 'ID',
+            resolve(root: ObjectionStorageProvider, _args, _ctx) {
+                return root.$modelClass.idColumn[0];
+            },
+        }),
         endpointUrl: t.exposeString('endpointUrl'),
         region: t.exposeString('region'),
         bucket: t.exposeString('bucket'),


### PR DESCRIPTION
Closes #79 

Basically the title. Adds in the generic types for the Pothos builder so we can get rid of the explicit any. Also appropriately resolve the ID columns from the Objection models.