### PR TITLE
Add List ML Models By Name Query

### DIFF
--- a/apollo/src/graphql/model/modelQueries.ts
+++ b/apollo/src/graphql/model/modelQueries.ts
@@ -21,4 +21,18 @@ builder.queryFields((t) => ({
             return mlModel;
         },
     }),
+    listMLModelByName: t.field({
+        type: [MLModel],
+        args: {
+            modelName: t.arg.string(),
+        },
+        async resolve(_root, args, _ctx) {
+            const mlModel = await ObjectionMLModel.query().where(
+                'modelName',
+                'LIKE',
+                `${args.modelName || ''}%`,
+            );
+            return mlModel;
+        },
+    }),
 }));

--- a/apollo/src/graphql/model/modelQueries.ts
+++ b/apollo/src/graphql/model/modelQueries.ts
@@ -4,8 +4,13 @@ import { builder } from '../../builder.js';
 builder.queryFields((t) => ({
     listMLModels: t.field({
         type: [MLModel],
-        async resolve(root, args, ctx) {
-            const mlModel = await ObjectionMLModel.query().orderBy('dateCreated');
+        args: {
+            modelName: t.arg.string(),
+        },
+        async resolve(_root, args, _ctx) {
+            const mlModel = await ObjectionMLModel.query()
+                .where('modelName', 'LIKE', `${args.modelName || ''}%`)
+                .orderBy('dateCreated');
             return mlModel;
         },
     }),
@@ -18,20 +23,6 @@ builder.queryFields((t) => ({
             const mlModel = (await ObjectionMLModel.query().findById(
                 args.modelId,
             )) as typeof MLModel.$inferType;
-            return mlModel;
-        },
-    }),
-    listMLModelByName: t.field({
-        type: [MLModel],
-        args: {
-            modelName: t.arg.string(),
-        },
-        async resolve(_root, args, _ctx) {
-            const mlModel = await ObjectionMLModel.query().where(
-                'modelName',
-                'LIKE',
-                `${args.modelName || ''}%`,
-            );
             return mlModel;
         },
     }),


### PR DESCRIPTION
This query is used by the frontend by allowing users to type into a search bar so that they can filter all of the ml models they currently have registered.