### PR TITLE
Add user authentication to context

### DIFF
--- a/apollo/src/index.ts
+++ b/apollo/src/index.ts
@@ -1,26 +1,72 @@
 import { Request } from 'express';
-import { ApolloServer } from '@apollo/server';
+import { ApolloServer, BaseContext } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { Model } from 'objection';
 import Knex from 'knex';
 import { knexConfig } from './knexfile.js';
 import { schema } from './graphql/index.js';
+import { JWTValidator } from './utils/jwt.js';
+import { JwtPayload } from 'jsonwebtoken';
+import { GraphQLError } from 'graphql';
+import { IncomingMessage } from 'http';
+import { create } from 'domain';
 
 const knex = Knex(knexConfig.development);
 Model.knex(knex);
 
-const context = async ({ req }: { req: Request }) => {
+interface UserAuthInterface {
+    userId: string;
+    dateCreated: number;
+    iat: number;
+    exp: number;
+}
+
+interface AuthContext extends BaseContext {
+    userAuth: UserAuthInterface;
+}
+
+const createContext = async ({ req }: { req: IncomingMessage }) => {
     // simple auth check on every request
     const auth = (req.headers && req.headers.authorization) || '';
-    return null;
+    if (auth.startsWith("Bearer ")){
+        const token = auth.substring(7, auth.length);
+        try {
+            const verifiedToken = JWT.verifySession(token) as JwtPayload;
+            const userAuth = {
+                userId: verifiedToken.userId,
+                dateCreated: verifiedToken.dateCreated,
+                iat: verifiedToken.iat as number,
+                exp: verifiedToken.exp as number,
+            };
+            return { userAuth };
+        } catch(err) {
+            // throw new GraphQLError('Authentication token is invalid', {
+            //     extensions: {
+            //       code: 'UNAUTHENTICATED',
+            //       http: { status: 401 },
+            //     },
+            // });
+            return {};
+        }
+    } else {
+        // throw new GraphQLError('User is not authenticated', {
+        //     extensions: {
+        //       code: 'UNAUTHENTICATED',
+        //       http: { status: 401 },
+        //     },
+        // });
+        return {};
+    }
 };
 
+const JWT = new JWTValidator;
 const server = new ApolloServer({
     schema,
 });
 
 const { url } = await startStandaloneServer(server, {
     listen: { port: 4000 },
+    context: createContext,
 });
 
 console.log(`🚀  Server ready at: ${url}`);


### PR DESCRIPTION
Refs #75

This checks the presence and validity of a user's JWT
auth token on each request and appends it to the request
context. Currently I'm not enforcing authentication since
I still need to look into how/whether I can apply it
globally within the apollo server context while still
carving out a couple of unauthenticated endpoints for
account creation and user login.

It's important to also note that the JWT stuff is only
stubbed out just to the point of functionality. Properly,
I need to build out separate refresh and authentication
tokens, and functionality to automatically regenerate the
auth token if the user presents an expired auth token with
a valid refresh token.

Lastly, any client that's interacting with this Apollo server
should present the JWT to it as an Authorization header
using the Bearer schema. I.e.,

```
Authorization: Bearer <token>
```
