### PR TITLE
Add framework for API Keys

### DIFF
--- a/apollo/package.json
+++ b/apollo/package.json
@@ -24,6 +24,7 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/react": "^18.2.18",
     "@types/react-dom": "^18.2.7",
+    "@types/uuid": "^9.0.7",
     "argon2": "^0.31.2",
     "aws-sdk": "^2.1523.0",
     "express": "^4.18.2",
@@ -33,7 +34,8 @@
     "nexus": "^1.3.0",
     "objection": "^3.1.1",
     "pg": "^8.11.2",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/apollo/pnpm-lock.yaml
+++ b/apollo/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   '@types/react-dom':
     specifier: ^18.2.7
     version: 18.2.7
+  '@types/uuid':
+    specifier: ^9.0.7
+    version: 9.0.7
   argon2:
     specifier: ^0.31.2
     version: 0.31.2
@@ -74,6 +77,9 @@ dependencies:
   ts-node:
     specifier: ^10.9.1
     version: 10.9.1(@types/node@20.4.6)(typescript@5.1.6)
+  uuid:
+    specifier: ^9.0.1
+    version: 9.0.1
 
 devDependencies:
   '@types/express':
@@ -190,7 +196,7 @@ packages:
       negotiator: 0.6.3
       node-abort-controller: 3.1.1
       node-fetch: 2.6.12
-      uuid: 9.0.0
+      uuid: 9.0.1
       whatwg-mimetype: 3.0.0
     transitivePeerDependencies:
       - encoding
@@ -1763,6 +1769,10 @@ packages:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
       '@types/node': 20.4.6
+
+  /@types/uuid@9.0.7:
+    resolution: {integrity: sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==}
+    dev: false
 
   /@typescript-eslint/eslint-plugin@6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.54.0)(typescript@5.1.6):
     resolution: {integrity: sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==}
@@ -4532,8 +4542,8 @@ packages:
     hasBin: true
     dev: false
 
-  /uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
     dev: false
 

--- a/apollo/src/builder.ts
+++ b/apollo/src/builder.ts
@@ -2,12 +2,12 @@ import SchemaBuilder from '@pothos/core';
 
 export const builder = new SchemaBuilder<{
     Context: {
-        // userAuth: {
-        //     userId: string;
-        //     dateCreated: number;
-        //     iat: number;
-        //     exp: number;
-        // };
+        userAuth: {
+            userId: string;
+            dateCreated: number;
+            iat: number;
+            exp: number;
+        };
     };
     DefaultFieldNullability: true;
 }>({

--- a/apollo/src/graphql/auth/auth.ts
+++ b/apollo/src/graphql/auth/auth.ts
@@ -1,0 +1,44 @@
+import { builder } from '../../builder.js';
+import { Model, AnyQueryBuilder } from 'objection';
+import { ObjectionUser } from '../user/user.js';
+
+export const ApiKey = builder.objectRef<ObjectionApiKey>('ApiKey');
+
+builder.objectType(ApiKey, {
+    fields: (t) => ({
+        apiKeyId: t.field({
+            type: 'ID',
+            resolve(root: ObjectionApiKey, _args, _ctx) {
+                return root.$id();
+            },
+        }),
+        userId: t.exposeString('userId'),
+        apiKey: t.exposeString('apiKey'),
+        isArchived: t.exposeBoolean('isArchived'),
+        dateCreated: t.exposeString('dateCreated'),
+    }),
+});
+
+export class ObjectionApiKey extends Model {
+    id!: string;
+    userId!: string;
+    apiKey!: string;
+    isArchived!: boolean;
+    dateCreated!: string;
+
+    static tableName = 'dstkUser.apiKey';
+    static get idColumn() {
+        return 'apiKeyId';
+    }
+
+    static relationMappings = () => ({
+        userEmail: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.apiKey.userId',
+                to: 'dstkUser.user.userId',
+            },
+        },
+    });
+}

--- a/apollo/src/graphql/user/user.ts
+++ b/apollo/src/graphql/user/user.ts
@@ -1,5 +1,6 @@
 import { builder } from '../../builder.js';
 import { Model, AnyQueryBuilder } from 'objection';
+import { ObjectionApiKey } from '../auth/auth.js';
 
 export const User = builder.objectRef<ObjectionUser>('User');
 
@@ -56,6 +57,14 @@ export class ObjectionUser extends Model {
             join: {
                 from: 'dstkUser.user.userId',
                 to: 'dstkUser.email.userId',
+            },
+        },
+        apiKeys: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionApiKey,
+            join: {
+                from: 'dstkUser.apiKey.userId',
+                to: 'dstkUser.user.userId',
             },
         },
     });

--- a/apollo/src/graphql/user/userMutations.ts
+++ b/apollo/src/graphql/user/userMutations.ts
@@ -1,0 +1,43 @@
+import { builder } from '../../builder.js';
+import { ApiKey, ObjectionApiKey } from '../auth/auth.js';
+import {v4 as uuidv4} from 'uuid';
+
+builder.mutationFields((t) => ({
+    createApiKey: t.field({
+        type: ApiKey,
+        async resolve(root, args, ctx) {
+            const results = ObjectionApiKey.transaction(async (trx) => {
+                const apiKey = uuidv4().replace(/-/g, "");
+                const userApiKey = await ObjectionApiKey.query(trx)
+                    .insertAndFetch({
+                        userId: ctx.userAuth.userId,
+                        apiKey: apiKey,
+                    })
+                    .first();
+
+                return userApiKey;
+            });
+            return results;
+        },
+    }),
+    archiveApiKey: t.field({
+        type: ApiKey,
+        args: {
+            apiKeyId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionApiKey.transaction(async (trx) => {
+                const userApiKey = await ObjectionApiKey.query(trx)
+                    .patchAndFetchById(
+                        args.apiKeyId,
+                        { isArchived: true }
+                    )
+                    .where('userId', ctx.userAuth.userId)
+                    .first();
+
+                return userApiKey;
+            });
+            return results;
+        },
+    }),
+}));

--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -1,0 +1,16 @@
+import { builder } from '../../builder.js';
+import { ApiKey, ObjectionApiKey } from '../auth/auth.js';
+
+builder.queryFields((t) => ({
+    listApiKeys: t.field({
+        type: [ApiKey],
+        async resolve(_root, args, _ctx) {
+            const apiKeys = await ObjectionApiKey.query()
+                .where({
+                    userId: _ctx.userAuth.userId,
+                    isArchived: false,
+                });
+            return apiKeys;
+        },
+    }),
+}));

--- a/apollo/src/index.ts
+++ b/apollo/src/index.ts
@@ -1,4 +1,3 @@
-import { Request } from 'express';
 import { ApolloServer, BaseContext } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { Model } from 'objection';
@@ -7,7 +6,6 @@ import { knexConfig } from './knexfile.js';
 import { schema } from './graphql/index.js';
 import { JWTValidator } from './utils/jwt.js';
 import { JwtPayload } from 'jsonwebtoken';
-import { GraphQLError } from 'graphql';
 import { IncomingMessage, ServerResponse } from 'http';
 
 const JWT = new JWTValidator;
@@ -37,6 +35,24 @@ const createContext = async ({ res, req }: { res: ServerResponse, req: IncomingM
             // });
             return {};
         }
+    } else if (auth.startsWith("Basic ")){
+        const token = auth.substring(6, auth.length);
+        try {
+            // const verifiedToken = JWT.verifySession(token) as JwtPayload;
+            const userAuth = {
+                userId: '',
+            };
+            return { userAuth };
+        } catch(err) {
+            // throw new GraphQLError('Authentication token is invalid', {
+            //     extensions: {
+            //       code: 'UNAUTHENTICATED',
+            //       http: { status: 401 },
+            //     },
+            // });
+            return {};
+        }
+
     } else {
         // throw new GraphQLError('User is not authenticated', {
         //     extensions: {

--- a/postgres/patches/20231229_user-api-key.sql
+++ b/postgres/patches/20231229_user-api-key.sql
@@ -1,0 +1,10 @@
+\connect dstk;
+
+CREATE TABLE dstk_user.api_key (
+    id           SERIAL      NOT NULL PRIMARY KEY,
+    api_key_id   UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    user_id      UUID        NOT NULL REFERENCES dstk_user.user(user_id),
+    api_key      VARCHAR(32) NOT NULL UNIQUE,
+    is_archived  BOOLEAN     NOT NULL DEFAULT FALSE,
+    date_created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
Refs #75

This adds the inital framework for us to support API Key
authentication as an alternative to JWTs for non-interactive
or programmatic use cases. This isn't meant to be functional
yet, just fleshing out some of the machinery that we'll need
to issue, revoke, and check API keys. In a future PR, I'd
still like to encrypt the keys in storage and also have to
build out a validation mechanism for them when supplied as
a basic auth header.
