### PR TITLE
Enforce model version uniqueness

### DIFF
--- a/postgres/patches/20231212_registry-models-table.sql
+++ b/postgres/patches/20231212_registry-models-table.sql
@@ -41,5 +41,6 @@ CREATE TABLE registry.model_versions (
     numeric_version  INTEGER NOT NULL,
     description      TEXT,
     metadata         JSON,
-    date_created     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    date_created     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE(model_id, numeric_version)
 );


### PR DESCRIPTION
In this commit, I'm a silly goose who forgot to include
a uniqueness constraint on model id and numeric version
leading to a fun race condition that could happen when
multiple requests to create a new version of the same
model were submitted at roughly the same time.

I.e., it was possible for:

  - Client A and Client B both query current model version
  - Both clients set the `incrementedVersion` to the same
    `n + 1` value
  - Client B `insertAndFetch`es first, and finalizes the
    transaction to create a new model version `n + 1`
  - Client A `insertAndFetch`es second, and also finalizes
    the transaction to create a new model version `n + 1`
  - There are now two versions of the same model with the
    same numeric version
  - This is a bad time.

Now, in the above scenario, Client A's transaction would
fail due to the uniqueness constraint, and the client
would have to resubmit the `createModelVersion` request
