### PR TITLE
Enforce user FKs on storage provider mutations

### DIFF
--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -85,7 +85,7 @@ builder.mutationFields((t) => ({
 
                 const partialSession = {
                     dateCreated: Date.now(),
-                    userId: userAccount.id,
+                    userId: userAccount.$id(),
                 }
                 const token = JWT.encodeSession(partialSession);
                 return token;

--- a/apollo/src/graphql/misc/limit.ts
+++ b/apollo/src/graphql/misc/limit.ts
@@ -4,7 +4,8 @@ import { LIMITS, type Limit } from '../../types/Limit.js';
 
 builder.scalarType('Limit', {
     serialize: (n) => n,
-    // @ts-expect-error This is a bug, according to the docs this should resolve correctly
+    // @ts-expect-error This is a bug, according to the
+    // docs this should resolve correctly
     // https://pothos-graphql.dev/docs/guide/scalars#defining-your-own-scalars
     parseValue: (n: Limit) => {
         if (LIMITS.includes(n)) {
@@ -13,4 +14,5 @@ builder.scalarType('Limit', {
 
         throw new InputError({ name: 'INVALID_LIMIT_ERROR' });
     },
+    description: 'Valid page sizes are 10, 25, and 50 records',
 });

--- a/apollo/src/graphql/user/user.ts
+++ b/apollo/src/graphql/user/user.ts
@@ -33,7 +33,7 @@ builder.objectType(User, {
 });
 
 export class ObjectionUser extends Model {
-    id!: string;
+    id!: number;
     isAdmin!: boolean;
     isApproved!: boolean;
     isDisabled!: boolean;

--- a/postgres/patches/20231212_registry-models-table.sql
+++ b/postgres/patches/20231212_registry-models-table.sql
@@ -10,9 +10,9 @@ CREATE TABLE registry.storage_providers (
     bucket            VARCHAR(64)  NOT NULL,
     access_key_id     TEXT         NOT NULL,
     secret_access_key TEXT         NOT NULL,
-    created_by        UUID         REFERENCES dstk_user.user(user_id),
-    modified_by       UUID         REFERENCES dstk_user.user(user_id),
-    owner             UUID         REFERENCES dstk_user.user(user_id),
+    created_by_id     INTEGER      NOT NULL REFERENCES dstk_user.user(id),
+    modified_by_id    INTEGER      NOT NULL REFERENCES dstk_user.user(id),
+    owner_id          INTEGER      NOT NULL REFERENCES dstk_user.user(id),
     date_created      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     date_modified     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
Resolves #33

This enforces the foreign key `NOT NULL` constraints on the
`ownerId`, `createdById`, and `modifiedById` columns on
`registry.storage_providers`.

As a consequence of this, all requests to storage provider
mutations must be authenticated or else they will fail. To
authenticate against these APIs, you will need to sequentially
invoke the `createAccount` and `login` mutations. E.g.,

```
mutation CreateAccount {
  createAccount(
    data: {
      email: "chris@dstk.org"
      password: "CowGoesMoo"
      realName: "Chris"
      userName: "chris"
    }
  ) {
    primaryEmail
    realName
    userId
    userName
  }
}

mutation Login {
  login(
    data: {
      password: "CowGoesMoo",
      userName: "chris"
    }
  )
}
```

This will yield a JWT auth token. In Apollo Studio, you can
add this token as an Authorization header by clicking the gear
icon in the top left next to the `localhost:4000/` endpoint and
adding a new Authorization header with the value `Bearer <token>`.

The method will differ if using other clients to interact with the
graphql API, but the format of the header will remain the same.

Using the above account as an example, creating a new, or editing
an existing, storage provider will now yield the correct user
details:

```
{
  "data": {
    "createStorageProvider": {
      "dateCreated": "1704045706430",
      "dateModified": "1704045706430",
      "isArchived": false,
      "owner": {
        "realName": "Chris",
        "userId": "05e1d4e6-35a0-4abf-91e4-5866124c8f93",
        "userName": "chris"
      },
      "modifiedBy": {
        "userName": "chris"
      },
      "createdBy": {
        "userName": "chris"
      }
    }
  }
}
```
