### PR TITLE
Resolve user in Apollo context

### DIFF
--- a/apollo/src/builder.ts
+++ b/apollo/src/builder.ts
@@ -1,15 +1,10 @@
 import SchemaBuilder from '@pothos/core';
-
 import type { Limit } from './types/Limit.js';
+import { ObjectionUser } from './graphql/index.js';
 
 export const builder = new SchemaBuilder<{
     Context: {
-        userAuth: {
-            userId: string;
-            dateCreated: number;
-            iat: number;
-            exp: number;
-        };
+        user: ObjectionUser,
     };
     DefaultFieldNullability: true;
     Scalars: {

--- a/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -1,7 +1,6 @@
 import { MLModelVersion, ObjectionMLModelVersion } from './modelVersion.js';
 import { ObjectionMLModel } from '../model/model.js';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
-import { ObjectionUser } from '../user/user.js';
 import { RegistryOperationError } from '../../utils/errors.js';
 import {
     AbortMultipartUpload,
@@ -69,9 +68,6 @@ builder.mutationFields((t) => ({
         },
         async resolve(root, args, ctx) {
             const results = ObjectionMLModelVersion.transaction(async (trx) => {
-                const user = (await ObjectionUser.query()
-                    .findById(ctx.userAuth.userId)) as ObjectionUser;
-
                 const parentModel = (await ObjectionMLModel.query()
                     .where('modelId', args.data.modelId)
                     .first()) as ObjectionMLModel;
@@ -96,7 +92,7 @@ builder.mutationFields((t) => ({
                         description: args.data?.description || raw('NULL'),
                         numericVersion: incrementedVersion,
                         s3Prefix: s3_prefix,
-                        createdById: user.$id(),
+                        createdById: ctx.user.$id(),
                     })
                     .first();
 

--- a/apollo/src/graphql/model/modelMutations.ts
+++ b/apollo/src/graphql/model/modelMutations.ts
@@ -2,7 +2,6 @@ import { MLModel, ObjectionMLModel } from './model.js';
 import { raw } from 'objection';
 import { RegistryOperationError } from '../../utils/errors.js';
 import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
-import { ObjectionUser } from '../user/user.js';
 import { builder } from '../../builder.js';
 
 export const ModelInputType = builder.inputType('ModelInput', {
@@ -21,9 +20,6 @@ builder.mutationFields((t) => ({
         },
         async resolve(root, args, ctx) {
             const results = ObjectionMLModel.transaction(async (trx) => {
-                const user = (await ObjectionUser.query()
-                    .findById(ctx.userAuth.userId)) as ObjectionUser;
-
                 const storageProvider = (await ObjectionStorageProvider.query().findById(
                     args.data.storageProviderId,
                 )) as ObjectionStorageProvider;
@@ -39,8 +35,8 @@ builder.mutationFields((t) => ({
                         storageProviderId: args.data.storageProviderId,
                         modelName: args.data.modelName,
                         description: args.data.description,
-                        createdById: user.$id(),
-                        modifiedById: user.$id(),
+                        createdById: ctx.user.$id(),
+                        modifiedById: ctx.user.$id(),
                     })
                     .first();
 
@@ -57,9 +53,6 @@ builder.mutationFields((t) => ({
         },
         async resolve(root, args, ctx) {
             const results = ObjectionMLModel.transaction(async (trx) => {
-                const user = (await ObjectionUser.query()
-                    .findById(ctx.userAuth.userId)) as ObjectionUser;
-
                 const storageProvider = (await ObjectionMLModel.relatedQuery('storageProvider')
                     .for(args.modelId)
                     .first()) as ObjectionStorageProvider;
@@ -71,7 +64,7 @@ builder.mutationFields((t) => ({
                     modelName: args.data.modelName,
                     description: args.data.description,
                     dateModified: raw('NOW()'),
-                    modifiedById: user.$id(),
+                    modifiedById: ctx.user.$id(),
                 });
                 if (mlModel.isArchived === true) {
                     throw new RegistryOperationError({ name: 'ARCHIVED_MODEL_ERROR' });
@@ -90,16 +83,13 @@ builder.mutationFields((t) => ({
         },
         async resolve(root, args, ctx) {
             const results = ObjectionMLModel.transaction(async (trx) => {
-                const user = (await ObjectionUser.query()
-                    .findById(ctx.userAuth.userId)) as ObjectionUser;
-
                 // Intentionally don't throw an error here on archived storage
                 // providers. It's not unreasonable to want to mark old assets
                 // as archived if their parent blob storage goes bye-bye
                 const mlModel = await ObjectionMLModel.query(trx).patchAndFetchById(args.modelId, {
                     isArchived: raw('NOT is_archived'),
                     dateModified: raw('NOW()'),
-                    modifiedById: user.$id(),
+                    modifiedById: ctx.user.$id(),
                 });
                 return mlModel as typeof MLModel.$inferType;
             });

--- a/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -1,5 +1,4 @@
 import { StorageProvider, ObjectionStorageProvider } from './storageProvider.js';
-import { ObjectionUser } from '../user/user.js';
 import { Security } from '../../utils/encryption.js';
 import { raw } from 'objection';
 import { builder } from '../../builder.js';
@@ -24,10 +23,6 @@ builder.mutationFields((t) => ({
         },
         async resolve(root, args, ctx) {
             const results = ObjectionStorageProvider.transaction(async (trx) => {
-                const user = (await ObjectionUser.query().findById(
-                    ctx.userAuth.userId,
-                )) as ObjectionUser;
-
                 const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
                 const encryptedSecretAccessKey = EncryptoMatic.encrypt(args.data.secretAccessKey);
 
@@ -38,9 +33,9 @@ builder.mutationFields((t) => ({
                         bucket: args.data.bucket,
                         accessKeyId: encryptedAccessKeyId,
                         secretAccessKey: encryptedSecretAccessKey,
-                        createdById: user.$id(),
-                        modifiedById: user.$id(),
-                        ownerId: user.$id(),
+                        createdById: ctx.user.$id(),
+                        modifiedById: ctx.user.$id(),
+                        ownerId: ctx.user.$id(),
                     })
                     .first();
                 return storageProvider as typeof StorageProvider.$inferType;
@@ -57,9 +52,6 @@ builder.mutationFields((t) => ({
         },
         async resolve(root, args, ctx) {
             const results = ObjectionStorageProvider.transaction(async (trx) => {
-                const user = (await ObjectionUser.query().findById(
-                    ctx.userAuth.userId,
-                )) as ObjectionUser;
                 const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
                 const encryptedSecretAccessKey = EncryptoMatic.encrypt(args.data.secretAccessKey);
 
@@ -72,7 +64,7 @@ builder.mutationFields((t) => ({
                         accessKeyId: encryptedAccessKeyId,
                         secretAccessKey: encryptedSecretAccessKey,
                         dateModified: raw('NOW()'),
-                        modifiedById: user.$id(),
+                        modifiedById: ctx.user.$id(),
                     },
                 );
                 return storageProvider as typeof StorageProvider.$inferType;
@@ -88,9 +80,6 @@ builder.mutationFields((t) => ({
         },
         async resolve(root, args, ctx) {
             const results = ObjectionStorageProvider.transaction(async (trx) => {
-                const user = (await ObjectionUser.query().findById(
-                    ctx.userAuth.userId,
-                )) as ObjectionUser;
                 const storageProvider = await ObjectionStorageProvider.query(trx).patchAndFetchById(
                     args.providerId,
                     {
@@ -98,7 +87,7 @@ builder.mutationFields((t) => ({
                         secretAccessKey: EncryptoMatic.encrypt('<DELETED>'),
                         accessKeyId: EncryptoMatic.encrypt('<DELETED>'),
                         dateModified: raw('NOW()'),
-                        modifiedById: user.$id(),
+                        modifiedById: ctx.user.$id(),
                     },
                 );
 

--- a/apollo/src/graphql/user/userMutations.ts
+++ b/apollo/src/graphql/user/userMutations.ts
@@ -10,7 +10,7 @@ builder.mutationFields((t) => ({
                 const apiKey = uuidv4().replace(/-/g, '');
                 const userApiKey = await ObjectionApiKey.query(trx)
                     .insertAndFetch({
-                        userId: ctx.userAuth.userId,
+                        userId: ctx.user.$id(),
                         apiKey: apiKey,
                     })
                     .first();
@@ -29,7 +29,7 @@ builder.mutationFields((t) => ({
             const results = ObjectionApiKey.transaction(async (trx) => {
                 const userApiKey = await ObjectionApiKey.query(trx)
                     .patchAndFetchById(args.apiKeyId, { isArchived: true })
-                    .where('userId', ctx.userAuth.userId)
+                    .where('userId', ctx.user.$id())
                     .first();
 
                 return userApiKey;

--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -6,7 +6,7 @@ builder.queryFields((t) => ({
         type: [ApiKey],
         async resolve(_root, args, _ctx) {
             const apiKeys = await ObjectionApiKey.query().where({
-                userId: _ctx.userAuth.userId,
+                userId: _ctx.user.$id(),
                 isArchived: false,
             });
             return apiKeys;

--- a/apollo/src/index.ts
+++ b/apollo/src/index.ts
@@ -7,6 +7,7 @@ import { schema } from './graphql/index.js';
 import { JWTValidator } from './utils/jwt.js';
 import { JwtPayload } from 'jsonwebtoken';
 import { IncomingMessage, ServerResponse } from 'http';
+import { ObjectionUser } from './graphql/index.js';
 
 const JWT = new JWTValidator();
 const knex = Knex(knexConfig.development);
@@ -19,13 +20,11 @@ const createContext = async ({ res, req }: { res: ServerResponse; req: IncomingM
         const token = auth.substring(7, auth.length);
         try {
             const verifiedToken = JWT.verifySession(token) as JwtPayload;
-            const userAuth = {
-                userId: verifiedToken.userId,
-                dateCreated: verifiedToken.dateCreated,
-                iat: verifiedToken.iat as number,
-                exp: verifiedToken.exp as number,
-            };
-            return { userAuth };
+            const user = (await ObjectionUser.query().findById(
+                verifiedToken.userId,
+            )) as ObjectionUser;
+
+            return { user: user };
         } catch (err) {
             // throw new GraphQLError('Authentication token is invalid', {
             //     extensions: {


### PR DESCRIPTION
This removes a lot of unnecessary duplication of user
resolution code. Now we're just taking the validated
JWT and immediately resolving it to a user object in
the context handler, rather than pushing it down into
individual mutations.
