### PR TITLE
Add basic support for Teams

### DIFF
--- a/apollo/src/graphql/index.ts
+++ b/apollo/src/graphql/index.ts
@@ -1,5 +1,3 @@
-export * from './user/user.js';
-
 export * from './auth/authMutations.js';
 
 export * from './model/model.js';
@@ -15,6 +13,10 @@ export * from './model-version/modelVersionQueries.js';
 export * from './storage-provider/storageProvider.js';
 export * from './storage-provider/storageProviderMutations.js';
 export * from './storage-provider/storageProviderQueries.js';
+
+export * from './user/user.js';
+export * from './user/team.js';
+export * from './user/teamMutations.js';
 
 export * from './misc/limit.js';
 export * from './misc/pageInfo.js';

--- a/apollo/src/graphql/misc/edges.ts
+++ b/apollo/src/graphql/misc/edges.ts
@@ -1,0 +1,9 @@
+import { Model } from 'objection';
+
+
+export class ObjectionEdge extends Model {
+    id!: number;
+    type!: string;
+
+    static tableName = 'dstkMetadata.edgeRelations';
+}

--- a/apollo/src/graphql/user/team.ts
+++ b/apollo/src/graphql/user/team.ts
@@ -1,0 +1,153 @@
+import { builder } from '../../builder.js';
+import { Model, AnyQueryBuilder } from 'objection';
+import { User, ObjectionUser } from '../user/user.js';
+import { ObjectionEdge } from '../misc/edges.js';
+import { deepStrictEqual } from 'assert';
+
+export const Team = builder.objectRef<ObjectionTeam>('Team');
+
+builder.objectType(Team, {
+    fields: (t) => ({
+        teamId: t.field({
+            type: 'ID',
+            resolve(root: ObjectionTeam, _args, _ctx) {
+                return root.$id();
+            },
+        }),
+        name: t.exposeString('name'),
+        description: t.exposeString('description'),
+        dateCreated: t.exposeString('dateCreated'),
+        dateModified: t.exposeString('dateModified'),
+        createdBy: t.field({
+            type: User,
+            async resolve(root: ObjectionTeam, _args, _ctx) {
+                const user = (await root.$relatedQuery('getCreatedBy')
+                    .for(root.$id())
+                    .first()) as ObjectionUser;
+                return user;
+            },
+        }),
+        modifiedBy: t.field({
+            type: User,
+            async resolve(root: ObjectionTeam, _args, _ctx) {
+                const user = (await root.$relatedQuery('getModifiedBy')
+                    .for(root.$id())
+                    .first()) as ObjectionUser;
+                return user;
+            },
+        }),
+        owner: t.field({
+            type: User,
+            async resolve(root: ObjectionTeam, _args, _ctx) {
+                const user = (await root.$relatedQuery('getOwnedBy')
+                    .for(root.$id())
+                    .first()) as ObjectionUser;
+                return user;
+            },
+        }),
+    }),
+});
+
+export class ObjectionTeam extends Model {
+    id!: number;
+    teamId!: string;
+    name!: string;
+    description!: string;
+    isArchived!: boolean;
+    dateCreated!: string;
+    dateModified!: string;
+    createdById!: string;
+    modifiedById!: string;
+    ownerId!: string;
+
+    createdBy!: ObjectionUser;
+    modifiedBy!: ObjectionUser;
+    ownedBy!: ObjectionUser;
+
+    static tableName = 'dstkUser.teams';
+    static get idColumn() {
+        return 'teamId';
+    }
+
+    static get modifiers() {
+        return {
+            filterByEdgeType(_builder: AnyQueryBuilder, edgeType: number) {
+                _builder.withGraphJoined('teamMembers')
+                    .where('dstkUser.teamEdges.edgeType', edgeType);
+            }
+        }
+    }
+
+    static relationMappings = () => ({
+        getCreatedBy: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.teams.createdById',
+                to: 'dstkUser.user.userId',
+            },
+        },
+        getModifiedBy: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.teams.modifiedById',
+                to: 'dstkUser.user.userId',
+            },
+        },
+        getOwnedBy: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.teams.ownerId',
+                to: 'dstkUser.user.userId',
+            },
+        },
+        teamMembers: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.teams.teamId',
+                through: {
+                    from: 'dstkUser.team_edges.teamId',
+                    to: 'dstkUser.team_edges.userId'
+                },
+                to: 'dstkUser.user.userId',
+            },
+        }
+    });
+}
+
+export class ObjectionTeamEdge extends Model {
+    teamId!: string;
+    edgeType!: number;
+    userId!: string;
+
+    static tableName = 'dstkUser.teamEdges';
+    static relationMappings = () => ({
+        user: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.teamEdges.userId',
+                to: 'dstkUser.user.userId'
+            },
+        },
+        team: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionTeam,
+            join: {
+                from: 'dstkUser.teamEdges.teamId',
+                to: 'dstkUser.team.teamId'
+            },
+        },
+        edgeTypeMapping: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionEdge,
+            join: {
+                from: 'dstkUser.teamEdges.edgeType',
+                to: 'dstkMetadata.edgeRelations.id'
+            },
+        },
+    });
+}

--- a/apollo/src/graphql/user/teamMutations.ts
+++ b/apollo/src/graphql/user/teamMutations.ts
@@ -1,0 +1,47 @@
+import { builder } from '../../builder.js';
+import { ObjectionEdge } from '../misc/edges.js';
+import { Team, ObjectionTeam, ObjectionTeamEdge, } from './team.js';
+
+
+export const TeamInputType = builder.inputType('TeamInput', {
+    fields: (t) => ({
+        name: t.string({ required: true }),
+        description: t.string({ required: true }),
+    }),
+});
+
+builder.mutationFields((t) => ({
+    createTeam: t.field({
+        type: Team,
+        args: {
+            data: t.arg({ type: TeamInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionTeam.transaction(async (trx) => {
+                const team = await ObjectionTeam.query(trx)
+                    .insertAndFetch({
+                        name: args.data.name,
+                        description: args.data.description,
+                        createdById: ctx.user.$id(),
+                        modifiedById: ctx.user.$id(),
+                        ownerId: ctx.user.$id(),
+                    })
+                    .first();
+
+                const ownerEdgeType = await ObjectionEdge.query()
+                    .where('type', 'owner')
+                    .first() as ObjectionEdge;
+                await ObjectionTeamEdge.query(trx)
+                    .insert({
+                        teamId: team.$id(),
+                        userId: ctx.user.$id(),
+                        edgeType: ownerEdgeType.id,
+                    })
+                    .returning('*');
+
+                return team;
+            });
+            return results;
+        },
+    }),
+}));

--- a/apollo/src/graphql/user/user.ts
+++ b/apollo/src/graphql/user/user.ts
@@ -72,7 +72,7 @@ export class ObjectionUser extends Model {
 }
 
 export class ObjectionUserEmail extends Model {
-    id!: string;
+    id!: number;
     userId!: string;
     emailAddress!: string;
     isVerified!: boolean;

--- a/postgres/patches/20240104_teams.sql
+++ b/postgres/patches/20240104_teams.sql
@@ -1,0 +1,33 @@
+\connect dstk;
+
+CREATE TABLE dstk_user.teams (
+    id             SERIAL      NOT NULL PRIMARY KEY,
+    team_id        UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    name           VARCHAR(64) NOT NULL,
+    description    TEXT,
+    is_archived    BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_by_id  VARCHAR(16) REFERENCES dstk_user.user(user_id),
+    modified_by_id VARCHAR(16) REFERENCES dstk_user.user(user_id),
+    owner_id       VARCHAR(16) REFERENCES dstk_user.user(user_id),
+    date_created   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    date_modified  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE dstk_metadata.edge_relations (
+    id   SERIAL      NOT NULL PRIMARY KEY,
+    type VARCHAR(12) NOT NULL
+);
+
+INSERT INTO dstk_metadata.edge_relations (type)
+VALUES
+    ('owner'),
+    ('member'),
+    ('viewer');
+
+CREATE TABLE dstk_user.team_edges (
+    team_id    UUID        NOT NULL REFERENCES dstk_user.teams(team_id),
+    edge_type  INTEGER     NOT NULL REFERENCES dstk_metadata.edge_relations(id),
+    user_id    VARCHAR(16) NOT NULL REFERENCES dstk_user.user(user_id)
+);
+
+COMMENT ON TABLE dstk_user.team_edges is 'Edge type reflects user relation to team';


### PR DESCRIPTION
Refs #75.

This adds basic support for teams and team creation
including backing database tables and a `createTeam`
mutation.

Note that for permissions, I'm using edges. Edges are
a generic way of storing a relationship between two
objects, and an edge is defined by an origin ID, a
destination ID, and an edge type which describes the
relationship. Every edge is inherently bidirectional,
although for simplicity I am choosing to not write an
inverse edge since this can effectively be achieved
already by just inverting the direction of a join.
