### PR TITLE
Add ability to add users to teams

### DIFF
--- a/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -12,21 +12,21 @@ import {
 import { raw } from 'objection';
 import { builder } from '../../builder.js';
 
-export const ModelVersionInputType = builder.inputType('ModelVersionInputType', {
+export const ModelVersionInputType = builder.inputType('ModelVersionInput', {
     fields: (t) => ({
         modelId: t.string({ required: true }),
         description: t.string(),
     }),
 });
 
-export const CompletedPartInputType = builder.inputType('CompletedPartInputType', {
+export const CompletedPartInputType = builder.inputType('CompletedPartInput', {
     fields: (t) => ({
         ETag: t.string({ required: true }),
         PartNumber: t.int({ required: true }),
     }),
 });
 
-export const PartsInputType = builder.inputType('PartsInputType', {
+export const PartsInputType = builder.inputType('PartsInput', {
     fields: (t) => ({
         Parts: t.field({
             required: true,
@@ -44,7 +44,7 @@ export const PresignMethod = builder.enumType('PresignMethod', {
     ] as const,
 });
 
-export const PresignedURLInputType = builder.inputType('PresignedURLInputType', {
+export const PresignedURLInputType = builder.inputType('PresignedURLInput', {
     fields: (t) => ({
         modelVersionId: t.string({ required: true }),
         method: t.field({

--- a/apollo/src/graphql/user/user.ts
+++ b/apollo/src/graphql/user/user.ts
@@ -1,6 +1,7 @@
 import { builder } from '../../builder.js';
 import { Model, AnyQueryBuilder } from 'objection';
 import { ObjectionApiKey } from '../auth/auth.js';
+import { ObjectionTeam, ObjectionTeamEdge } from './team.js';
 
 export const User = builder.objectRef<ObjectionUser>('User');
 
@@ -68,6 +69,14 @@ export class ObjectionUser extends Model {
                 to: 'dstkUser.user.userId',
             },
         },
+        teamEdges: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionTeamEdge,
+            join: {
+                from: 'dstkUser.user.userId',
+                to: 'dstkUser.teamEdges.userId'
+            }
+        }
     });
 }
 

--- a/apollo/src/utils/errors.ts
+++ b/apollo/src/utils/errors.ts
@@ -5,7 +5,8 @@ type RegistryErrorName =
     | 'PUBLISHED_MODEL_VERSION_ERROR'
     | 'MISSING_UPLOAD_ID_ERROR'
     | 'MISSING_PART_NUM_ERROR'
-    | 'MULTIPART_FINALIZATION_ERROR';
+    | 'MULTIPART_FINALIZATION_ERROR'
+    | 'TEAM_PERMISSION_ERROR';
 
 const RegistryErrorMessages = {
     ARCHIVED_STORAGE_ERROR: 'New model versions cannot be added to an archived storage provider',
@@ -16,6 +17,7 @@ const RegistryErrorMessages = {
     MISSING_PART_NUM_ERROR: 'A Part Number must be supuplied for this operation',
     MULTIPART_FINALIZATION_ERROR:
         'Uploaded parts and their ETags must be supplied to finalize a MPU',
+    TEAM_PERMISSION_ERROR: 'Either this team doesn\'t exist or you don\'t have permission to take that action',
 };
 
 export class RegistryOperationError extends Error {

--- a/postgres/patches/20230803_users.sql
+++ b/postgres/patches/20230803_users.sql
@@ -20,7 +20,7 @@ CREATE TABLE dstk_user.email (
     id                SERIAL       NOT NULL PRIMARY KEY,
     email_id          UUID         NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
     user_id           VARCHAR(16)  NOT NULL REFERENCES dstk_user.user(user_id),
-    email_address     VARCHAR(128) NOT NULL UNIQUE,
+    email_address     VARCHAR(128) NOT NULL,
     is_verified       BOOLEAN      NOT NULL DEFAULT FALSE,
     is_primary        BOOLEAN      NOT NULL,
     verification_code VARCHAR(64),

--- a/postgres/patches/20240104_teams.sql
+++ b/postgres/patches/20240104_teams.sql
@@ -8,7 +8,6 @@ CREATE TABLE dstk_user.teams (
     is_archived    BOOLEAN     NOT NULL DEFAULT FALSE,
     created_by_id  VARCHAR(16) REFERENCES dstk_user.user(user_id),
     modified_by_id VARCHAR(16) REFERENCES dstk_user.user(user_id),
-    owner_id       VARCHAR(16) REFERENCES dstk_user.user(user_id),
     date_created   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     date_modified  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
@@ -25,9 +24,11 @@ VALUES
     ('viewer');
 
 CREATE TABLE dstk_user.team_edges (
-    team_id    UUID        NOT NULL REFERENCES dstk_user.teams(team_id),
-    edge_type  INTEGER     NOT NULL REFERENCES dstk_metadata.edge_relations(id),
-    user_id    VARCHAR(16) NOT NULL REFERENCES dstk_user.user(user_id)
+    id        BIGSERIAL   NOT NULL PRIMARY KEY,
+    team_id   UUID        NOT NULL REFERENCES dstk_user.teams(team_id),
+    edge_type INTEGER     NOT NULL REFERENCES dstk_metadata.edge_relations(id),
+    user_id   VARCHAR(16) NOT NULL REFERENCES dstk_user.user(user_id),
+    UNIQUE(user_id, team_id)
 );
 
 COMMENT ON TABLE dstk_user.team_edges is 'Edge type reflects user relation to team';


### PR DESCRIPTION
Ref #75

This adds the ability to add other users to teams and
to edit users' permissions within a team. Both operations
use the same `addToTeam` mutation; it performs an internal
check to see if an edge already exists for that user:team
relation and patches the edge if one's already present.
