### PR TITLE
Add Pothos auth plugin

### DIFF
--- a/apollo/pnpm-lock.yaml
+++ b/apollo/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@apollo/server':
     specifier: ^4.9.0
@@ -2070,8 +2074,10 @@ packages:
       - supports-color
     dev: false
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -3694,7 +3700,7 @@ packages:
       knex: '>=1.0.1'
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       db-errors: 0.2.3
       knex: 2.5.1(pg@8.11.2)
     dev: false
@@ -4696,7 +4702,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/apollo/src/builder.ts
+++ b/apollo/src/builder.ts
@@ -1,8 +1,13 @@
 import SchemaBuilder from '@pothos/core';
 import type { Limit } from './types/Limit.js';
 import { ObjectionUser } from './graphql/index.js';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
 
 export const builder = new SchemaBuilder<{
+    AuthScopes: {
+        anonymousRequest: boolean,
+        loggedIn: boolean,
+    };
     Context: {
         user: ObjectionUser,
     };
@@ -14,6 +19,11 @@ export const builder = new SchemaBuilder<{
         };
     };
 }>({
+    plugins: [ScopeAuthPlugin],
+    authScopes: async (context) => ({
+        anonymousRequest: !!!context.user.userId,
+        loggedIn: !!context.user.userId,
+    }),
     defaultFieldNullability: true,
 });
 

--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -4,6 +4,7 @@ import { HashBrown } from '../../utils/encryption.js';
 import { JWTValidator, PartialSession } from '../../utils/jwt.js';
 import { builder } from '../../builder.js';
 import { raw } from 'objection';
+import { convertSDL } from 'nexus';
 
 export const AccountInputType = builder.inputType('AccountInput', {
     fields: (t) => ({
@@ -24,6 +25,9 @@ export const LoginInputType = builder.inputType('LoginInput', {
 builder.mutationFields((t) => ({
     createAccount: t.field({
         type: User,
+        authScopes: {
+            anonymousRequest: true,
+        },
         args: {
             data: t.arg({ type: AccountInputType, required: true }),
         },

--- a/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -62,6 +62,9 @@ export const PresignedURLInputType = builder.inputType('PresignedURLInput', {
 
 builder.mutationFields((t) => ({
     createModelVersion: t.field({
+        authScopes: {
+            loggedIn: true,
+        },
         type: MLModelVersion,
         args: {
             data: t.arg({ type: ModelVersionInputType, required: true }),
@@ -108,6 +111,9 @@ builder.mutationFields((t) => ({
     }),
     publishModelVersion: t.field({
         type: MLModelVersion,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             modelVersionId: t.arg.string({ required: true }),
         },
@@ -134,6 +140,9 @@ builder.mutationFields((t) => ({
     }),
     archiveModelVersion: t.field({
         type: MLModelVersion,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             modelVersionId: t.arg.string({ required: true }),
         },
@@ -157,6 +166,9 @@ builder.mutationFields((t) => ({
     }),
     presignURL: t.field({
         type: PresignedURL,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             data: t.arg({ type: PresignedURLInputType, required: true }),
         },

--- a/apollo/src/graphql/model-version/modelVersionQueries.ts
+++ b/apollo/src/graphql/model-version/modelVersionQueries.ts
@@ -4,6 +4,9 @@ import { builder } from '../../builder.js';
 builder.queryFields((t) => ({
     listMLModelVersions: t.field({
         type: [MLModelVersion],
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             modelId: t.arg.string({ required: true }),
         },

--- a/apollo/src/graphql/model/modelMutations.ts
+++ b/apollo/src/graphql/model/modelMutations.ts
@@ -15,6 +15,9 @@ export const ModelInputType = builder.inputType('ModelInput', {
 builder.mutationFields((t) => ({
     createModel: t.field({
         type: MLModel,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             data: t.arg({ type: ModelInputType, required: true }),
         },
@@ -47,6 +50,9 @@ builder.mutationFields((t) => ({
     }),
     editModel: t.field({
         type: MLModel,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             modelId: t.arg.string({ required: true }),
             data: t.arg({ type: ModelInputType, required: true }),
@@ -78,6 +84,9 @@ builder.mutationFields((t) => ({
     }),
     archiveModel: t.field({
         type: MLModel,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             modelId: t.arg.string({ required: true }),
         },

--- a/apollo/src/graphql/model/modelQueries.ts
+++ b/apollo/src/graphql/model/modelQueries.ts
@@ -5,6 +5,9 @@ import { MLModelConnection } from './modelConnection.js';
 builder.queryFields((t) => ({
     listMLModels: t.field({
         type: MLModelConnection,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             modelName: t.arg.string(),
             first: t.arg({

--- a/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -18,6 +18,9 @@ export const StorageProviderInputType = builder.inputType('StorageProviderInput'
 builder.mutationFields((t) => ({
     createStorageProvider: t.field({
         type: StorageProvider,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             data: t.arg({ type: StorageProviderInputType, required: true }),
         },
@@ -46,6 +49,9 @@ builder.mutationFields((t) => ({
     }),
     editStorageProvider: t.field({
         type: StorageProvider,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             providerId: t.arg.string({ required: true }),
             data: t.arg({ type: StorageProviderInputType, required: true }),
@@ -75,6 +81,9 @@ builder.mutationFields((t) => ({
     }),
     archiveStorageProvider: t.field({
         type: StorageProvider,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             providerId: t.arg.string({ required: true }),
         },

--- a/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -4,6 +4,9 @@ import { builder } from '../../builder.js';
 builder.queryFields((t) => ({
     listStorageProviders: t.field({
         type: [StorageProvider],
+        authScopes: {
+            loggedIn: true,
+        },
         async resolve(root, args, ctx) {
             const storageProvider = await ObjectionStorageProvider.query().orderBy('dateCreated');
             return storageProvider;
@@ -11,6 +14,9 @@ builder.queryFields((t) => ({
     }),
     getStorageProvider: t.field({
         type: StorageProvider,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             storageProviderId: t.arg.string({ required: true }),
         },

--- a/apollo/src/graphql/user/teamMutations.ts
+++ b/apollo/src/graphql/user/teamMutations.ts
@@ -32,6 +32,9 @@ export const AddTeamMemberInputType = builder.inputType('AddTeamMemberInput', {
 builder.mutationFields((t) => ({
     createTeam: t.field({
         type: Team,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             data: t.arg({ type: TeamInputType, required: true }),
         },
@@ -63,6 +66,9 @@ builder.mutationFields((t) => ({
         },
     }),
     addToTeam: t.boolean({
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             data: t.arg({ type: AddTeamMemberInputType, required: true }),
         },

--- a/apollo/src/graphql/user/userMutations.ts
+++ b/apollo/src/graphql/user/userMutations.ts
@@ -5,6 +5,9 @@ import { v4 as uuidv4 } from 'uuid';
 builder.mutationFields((t) => ({
     createApiKey: t.field({
         type: ApiKey,
+        authScopes: {
+            loggedIn: true,
+        },
         async resolve(root, args, ctx) {
             const results = ObjectionApiKey.transaction(async (trx) => {
                 const apiKey = uuidv4().replace(/-/g, '');
@@ -22,6 +25,9 @@ builder.mutationFields((t) => ({
     }),
     archiveApiKey: t.field({
         type: ApiKey,
+        authScopes: {
+            loggedIn: true,
+        },
         args: {
             apiKeyId: t.arg.string({ required: true }),
         },

--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -4,6 +4,9 @@ import { ApiKey, ObjectionApiKey } from '../auth/auth.js';
 builder.queryFields((t) => ({
     listApiKeys: t.field({
         type: [ApiKey],
+        authScopes: {
+            loggedIn: true,
+        },
         async resolve(_root, args, _ctx) {
             const apiKeys = await ObjectionApiKey.query().where({
                 userId: _ctx.user.$id(),

--- a/apollo/src/index.ts
+++ b/apollo/src/index.ts
@@ -32,16 +32,13 @@ const createContext = async ({ res, req }: { res: ServerResponse; req: IncomingM
             //       http: { status: 401 },
             //     },
             // });
-            return {};
+            return { user: ObjectionUser };
         }
     } else if (auth.startsWith('Basic ')) {
         const token = auth.substring(6, auth.length);
         try {
             // const verifiedToken = JWT.verifySession(token) as JwtPayload;
-            const userAuth = {
-                userId: '',
-            };
-            return { userAuth };
+            return { user: ObjectionUser };
         } catch (err) {
             // throw new GraphQLError('Authentication token is invalid', {
             //     extensions: {
@@ -49,7 +46,7 @@ const createContext = async ({ res, req }: { res: ServerResponse; req: IncomingM
             //       http: { status: 401 },
             //     },
             // });
-            return {};
+            return { user: ObjectionUser };
         }
     } else {
         // throw new GraphQLError('User is not authenticated', {
@@ -58,7 +55,7 @@ const createContext = async ({ res, req }: { res: ServerResponse; req: IncomingM
         //       http: { status: 401 },
         //     },
         // });
-        return {};
+        return { user: ObjectionUser };
     }
 };
 


### PR DESCRIPTION
This adds a simple authentication check to queries and
mutations. I've defined two scopes: `loggedIn` and
`anonymousRequest`. Queries and mutations can specify
what scope, if any, is requred to invoke them by adding
```typescript
...
    authScopes: {
        <scope>: true,
    }
...
```
to the field definition.

Omitting a scope entirely leaves a method completely
unauthenticated. I added the explicit `anonymousRequest`
scope just because some mutations (like account creation)
we probably don't want to let an authenticated user invoke.

Note that these scopes do not check whether a user is
_authorized_ to query or mutate any data; only whether they
have been authenticated as who they claim to be.
