### PR TITLE
Add Created At Field to Model Cursor

### DIFF
--- a/apollo/src/graphql/metadata/cursor.ts
+++ b/apollo/src/graphql/metadata/cursor.ts
@@ -16,7 +16,6 @@ builder.objectType(Cursor, {
                 return root.cursorRelation;
             },
         }),
-        resultId: t.exposeInt('resultId'),
         expiration: t.exposeString('expiration'),
     }),
 });
@@ -25,7 +24,6 @@ export class ObjectionCursor extends Model {
     id!: number;
     cursorToken!: string;
     cursorRelation!: 'model' | 'model_version';
-    resultId!: number;
     expiration!: string;
 
     static tableName = 'dstk_metadata.cursors';

--- a/apollo/src/graphql/model/modelQueries.ts
+++ b/apollo/src/graphql/model/modelQueries.ts
@@ -48,7 +48,7 @@ builder.queryFields((t) => ({
 
                     query
                         .where('dateCreated', '>=', new Date(dateCreated).toISOString())
-                        .andWhere('id', '>', parseInt(id));
+                        .andWhere('id', '>', id);
                 } else {
                     throw new CursorError({ name: 'TOKEN_DOES_NOT_EXIST' });
                 }
@@ -78,7 +78,7 @@ builder.queryFields((t) => ({
                 : edges.length > 0
                 ? await ObjectionCursor.query().insertAndFetch({
                       cursorToken: encoder.encode(
-                          edges[edges.length - 1].id.toString(),
+                          edges[edges.length - 1].id,
                           edges[edges.length - 1].dateCreated,
                       ),
                       cursorRelation: 'model',

--- a/apollo/src/utils/encoder.ts
+++ b/apollo/src/utils/encoder.ts
@@ -1,11 +1,11 @@
 export class Encoder {
     // TODO: Change this to include more fields
-    encode(id: string) {
-        return Buffer.from(id, 'utf8').toString('base64');
+    encode(...args: (string | number)[]) {
+        return Buffer.from(args.join(':'), 'utf8').toString('base64');
     }
 
     // TODO: Change this when more fields are included
     decode(encodedString: string) {
-        return Buffer.from(encodedString, 'base64').toString('utf8');
+        return Buffer.from(encodedString, 'base64').toString('utf8').split(':');
     }
 }

--- a/postgres/patches/20240106_cursor-metadata-table.sql
+++ b/postgres/patches/20240106_cursor-metadata-table.sql
@@ -8,9 +8,8 @@ CREATE TYPE cursor_relations AS ENUM (
 CREATE TABLE dstk_metadata.cursors (
     id                 SERIAL           NOT NULL PRIMARY KEY,
     cursor_id          UUID             NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
-    cursor_token       VARCHAR(12)      NOT NULL,
+    cursor_token       VARCHAR(128)     NOT NULL,
     cursor_relation    CURSOR_RELATIONS NOT NULL,
-    result_id          BIGINT           NOT NULL REFERENCES registry.models(id),
     expiration         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '5 minute',
     UNIQUE(cursor_relation, result_id)
 );

--- a/postgres/patches/20240106_remove-cursor-result-id.sql
+++ b/postgres/patches/20240106_remove-cursor-result-id.sql
@@ -1,6 +1,0 @@
-\connect dstk;
-
-ALTER TABLE dstk_metadata.cursors DROP COLUMN result_id;
-
-ALTER TABLE dstk_metadata.cursors
-ALTER COLUMN cursor_token TYPE VARCHAR(128);

--- a/postgres/patches/20240106_remove-cursor-result-id.sql
+++ b/postgres/patches/20240106_remove-cursor-result-id.sql
@@ -1,0 +1,6 @@
+\connect dstk;
+
+ALTER TABLE dstk_metadata.cursors DROP COLUMN result_id;
+
+ALTER TABLE dstk_metadata.cursors
+ALTER COLUMN cursor_token TYPE VARCHAR(128);


### PR DESCRIPTION
Previously the `result_id` of `dstk_metadata.cursors` was a foreign key reference to the serial ID of `registry.models`. The thought was that we eventually wanted to add in the `date_created` field from `registry.models` so the reference would make it easy to grab this column.

However, we really want the `result_id` to be able to reference different IDs since the goal of `dstk_metadata.cursors` is to be general-purpose and reusable. The original plan was to remove the FK reference to `registry.models` and to add in an additional `date_created` field to `dstk_metadata.cursors`. But since we are already encoding the cursor, we can simply decode it and use the values from that in the different where clauses as needed.

Thus, the `result_id` column was removed entirely and we strictly rely on the encoding / decoding of the continuation token to appropriately sort the paginated results.