### PR TITLE
Implement Projects

### DIFF
--- a/apollo/src/builder.ts
+++ b/apollo/src/builder.ts
@@ -21,8 +21,8 @@ export const builder = new SchemaBuilder<{
 }>({
     plugins: [ScopeAuthPlugin],
     authScopes: async (context) => ({
-        anonymousRequest: !!!context.user.userId,
-        loggedIn: !!context.user.userId,
+        anonymousRequest: !!!context.user?.userId,
+        loggedIn: !!context.user?.userId,
     }),
     defaultFieldNullability: true,
 });

--- a/apollo/src/graphql/index.ts
+++ b/apollo/src/graphql/index.ts
@@ -15,6 +15,9 @@ export * from './storage-provider/storageProviderMutations.js';
 export * from './storage-provider/storageProviderQueries.js';
 
 export * from './user/user.js';
+export * from './user/project.js';
+export * from './user/projectMutations.js';
+export * from './user/projectQueries.js';
 export * from './user/team.js';
 export * from './user/teamMutations.js';
 export * from './user/teamQueries.js';

--- a/apollo/src/graphql/user/project.ts
+++ b/apollo/src/graphql/user/project.ts
@@ -1,0 +1,88 @@
+import { builder } from '../../builder.js';
+import { Model } from 'objection';
+import { User, ObjectionUser } from '../user/user.js';
+import { ObjectionTeam } from './team.js';
+
+export const Project = builder.objectRef<ObjectionProject>('Project');
+
+builder.objectType(Project, {
+    fields: (t) => ({
+        projectId: t.field({
+            type: 'ID',
+            resolve(root: ObjectionProject, _args, _ctx) {
+                return root.$id();
+            },
+        }),
+        name: t.exposeString('name'),
+        description: t.exposeString('description'),
+        isArchived: t.exposeBoolean('isArchived'),
+        dateCreated: t.exposeString('dateCreated'),
+        dateModified: t.exposeString('dateModified'),
+        createdBy: t.field({
+            type: User,
+            async resolve(root: ObjectionProject, _args, _ctx) {
+                const user = (await root.$relatedQuery('getCreatedBy')
+                    .for(root.$id())
+                    .first()) as ObjectionUser;
+                return user;
+            },
+        }),
+        modifiedBy: t.field({
+            type: User,
+            async resolve(root: ObjectionProject, _args, _ctx) {
+                const user = (await root.$relatedQuery('getModifiedBy')
+                    .for(root.$id())
+                    .first()) as ObjectionUser;
+                return user;
+            },
+        }),
+    }),
+});
+
+export class ObjectionProject extends Model {
+    id!: number;
+    projectId!: string;
+    teamId!: string;
+    name!: string;
+    description!: string;
+    isArchived!: boolean;
+    dateCreated!: string;
+    dateModified!: string;
+    createdById!: string;
+    modifiedById!: string;
+
+    createdBy!: ObjectionUser;
+    modifiedBy!: ObjectionUser;
+
+    static tableName = 'dstkUser.projects';
+    static get idColumn() {
+        return 'projectId';
+    }
+
+    static relationMappings = () => ({
+        getCreatedBy: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.projects.createdById',
+                to: 'dstkUser.user.userId',
+            },
+        },
+        getModifiedBy: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionUser,
+            join: {
+                from: 'dstkUser.projects.modifiedById',
+                to: 'dstkUser.user.userId',
+            },
+        },
+        team: {
+            relation: Model.HasOneRelation,
+            modelClass: ObjectionTeam,
+            join: {
+                from: 'dstkUser.projects.teamId',
+                to: 'dstkUser.teams.teamId',
+            },
+        }
+    });
+}

--- a/apollo/src/graphql/user/projectMutations.ts
+++ b/apollo/src/graphql/user/projectMutations.ts
@@ -1,0 +1,82 @@
+import { builder } from '../../builder.js';
+import { Project, ObjectionProject } from './project.js';
+import { ObjectionTeamEdge } from './team.js';
+import { RegistryOperationError } from '../../utils/errors.js';
+import { raw } from 'objection';
+
+export const ProjectInputType = builder.inputType('ProjectInput', {
+    fields: (t) => ({
+        name: t.string({ required: true }),
+        description: t.string({ required: true }),
+        teamId: t.string({ required: true }),
+    }),
+});
+
+builder.mutationFields((t) => ({
+    createProject: t.field({
+        type: Project,
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            data: t.arg({ type: ProjectInputType, required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionProject.transaction(async (trx) => {
+                await ObjectionTeamEdge.userHasRole(
+                    ctx.user.$id(),
+                    args.data.teamId,
+                    ['owner', 'member']
+                );
+
+                const project = await ObjectionProject.query(trx)
+                    .insertAndFetch({
+                        name: args.data.name,
+                        description: args.data.description,
+                        createdById: ctx.user.$id(),
+                        modifiedById: ctx.user.$id(),
+                        teamId: args.data.teamId,
+                    })
+                    .first();
+
+                return project;
+            });
+            return results;
+        },
+    }),
+    archiveProject: t.field({
+        type: Project,
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            projectId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const results = ObjectionProject.transaction(async (trx) => {
+                const project = await ObjectionProject.query()
+                    .for(args.projectId)
+                    .first();
+                if (project === undefined) {
+                    throw new RegistryOperationError({ name: 'PROJECT_PERMISSION_ERROR' });
+                }
+
+                await ObjectionTeamEdge.userHasRole(
+                    ctx.user.$id(),
+                    project.teamId,
+                    ['owner', 'member']
+                );
+
+                await project.$query(trx)
+                    .updateAndFetch({
+                        modifiedById: ctx.user.$id(),
+                        dateModified: raw('NOW()'),
+                        isArchived: raw('NOT is_archived'),
+                    });
+
+                return project;
+            });
+            return results;
+        }
+    })
+}));

--- a/apollo/src/graphql/user/projectQueries.ts
+++ b/apollo/src/graphql/user/projectQueries.ts
@@ -1,0 +1,52 @@
+import { Project, ObjectionProject } from './project.js';
+import { ObjectionTeam, ObjectionTeamEdge } from './team.js';
+import { builder } from '../../builder.js';
+import { RegistryOperationError } from '../../utils/errors.js';
+
+builder.queryFields((t) =>({
+    listProjects: t.field({
+        type: [Project],
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            teamId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            await ObjectionTeamEdge.userHasRole(
+                ctx.user.$id(),
+                args.teamId,
+                ['owner', 'member', 'viewer']
+            );
+
+            const projects = await ObjectionTeam.relatedQuery('projects')
+                .for(args.teamId) as [ObjectionProject];
+            return projects;
+        },
+    }),
+    getProject: t.field({
+        type: Project,
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            projectId: t.arg.string({ required: true }),
+        },
+        async resolve(root, args, ctx) {
+            const project = await ObjectionProject.query()
+                .for(args.projectId)
+                .first();
+            if (project === undefined) {
+                throw new RegistryOperationError({ name: 'PROJECT_PERMISSION_ERROR' });
+            }
+            
+            await ObjectionTeamEdge.userHasRole(
+                ctx.user.$id(),
+                project.teamId,
+                ['owner', 'member', 'viewer']
+            );
+
+            return project;
+        },
+    })
+}));

--- a/apollo/src/graphql/user/team.ts
+++ b/apollo/src/graphql/user/team.ts
@@ -3,6 +3,7 @@ import { Model, AnyQueryBuilder } from 'objection';
 import { User, ObjectionUser } from '../user/user.js';
 import { ObjectionEdge } from '../misc/edges.js';
 import { RegistryOperationError } from '../../utils/errors.js';
+import { ObjectionProject } from './project.js';
 
 export const Team = builder.objectRef<ObjectionTeam>('Team');
 
@@ -49,7 +50,6 @@ export class ObjectionTeam extends Model {
     dateModified!: string;
     createdById!: string;
     modifiedById!: string;
-    ownerId!: string;
 
     createdBy!: ObjectionUser;
     modifiedBy!: ObjectionUser;
@@ -94,7 +94,15 @@ export class ObjectionTeam extends Model {
                 },
                 to: 'dstkUser.user.userId',
             },
-        }
+        },
+        projects: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionProject,
+            join: {
+                from: 'dstkUser.teams.teamId',
+                to: 'dstkUser.projects.teamId',
+            },
+        },
     });
 }
 
@@ -106,7 +114,7 @@ export class ObjectionTeamEdge extends Model {
 
     static tableName = 'dstkUser.teamEdges';
 
-    static async userHasRole(userId: string, teamId: string, roles: [string]) {
+    static async userHasRole(userId: string, teamId: string, roles: string[]) {
         const auth = await ObjectionTeamEdge.query()
             .withGraphJoined('edgeTypeMapping')
             .whereIn('edgeTypeMapping.type', roles)

--- a/apollo/src/graphql/user/teamMutations.ts
+++ b/apollo/src/graphql/user/teamMutations.ts
@@ -1,6 +1,6 @@
 import { builder } from '../../builder.js';
 import { ObjectionEdge } from '../misc/edges.js';
-import { Team, ObjectionTeam, ObjectionTeamEdge, } from './team.js';
+import { Team, ObjectionTeam, ObjectionTeamEdge } from './team.js';
 
 
 export const TeamInputType = builder.inputType('TeamInput', {

--- a/apollo/src/graphql/user/teamQueries.ts
+++ b/apollo/src/graphql/user/teamQueries.ts
@@ -32,14 +32,11 @@ builder.queryFields((t) =>({
             teamId: t.arg.string({ required: true }),
         },
         async resolve(root, args, ctx) {
-            const userCanView = await ObjectionTeamEdge.query()
-                .where({
-                    userId: ctx.user.$id(),
-                    teamId: args.teamId
-                }).first();
-            if (userCanView === undefined) {
-                return [];
-            }
+            await ObjectionTeamEdge.userHasRole(
+                ctx.user.$id(),
+                args.teamId,
+                ['owner', 'member', 'viewer']
+            );
 
             const teamMembers = await ObjectionTeam.relatedQuery('teamMembers')
                 .for(args.teamId) as [ObjectionUser];

--- a/apollo/src/utils/errors.ts
+++ b/apollo/src/utils/errors.ts
@@ -6,7 +6,8 @@ type RegistryErrorName =
     | 'MISSING_UPLOAD_ID_ERROR'
     | 'MISSING_PART_NUM_ERROR'
     | 'MULTIPART_FINALIZATION_ERROR'
-    | 'TEAM_PERMISSION_ERROR';
+    | 'TEAM_PERMISSION_ERROR'
+    | 'PROJECT_PERMISSION_ERROR';
 
 const RegistryErrorMessages = {
     ARCHIVED_STORAGE_ERROR: 'New model versions cannot be added to an archived storage provider',
@@ -19,6 +20,8 @@ const RegistryErrorMessages = {
         'Uploaded parts and their ETags must be supplied to finalize a MPU',
     TEAM_PERMISSION_ERROR:
         "Either this team doesn't exist or you don't have permission to take that action",
+    PROJECT_PERMISSION_ERROR:
+        "Either this project doesn't exist or you don't have permission to take that action",
 };
 
 export class RegistryOperationError extends Error {

--- a/postgres/patches/20240108_projects.sql
+++ b/postgres/patches/20240108_projects.sql
@@ -1,0 +1,14 @@
+\connect dstk;
+
+CREATE TABLE dstk_user.projects (
+    id             SERIAL      NOT NULL PRIMARY KEY,
+    project_id     UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    team_id        UUID        NOT NULL REFERENCES dstk_user.teams(team_id),
+    name           VARCHAR(64) NOT NULL,
+    description    TEXT,
+    is_archived    BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_by_id  VARCHAR(16) REFERENCES dstk_user.user(user_id),
+    modified_by_id VARCHAR(16) REFERENCES dstk_user.user(user_id),
+    date_created   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    date_modified  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
This implements projects as children of Teams. Any
member of a team with some level of write access can
create and modify projects. As a next step, I plan to
modify models so that they are children of projects.

Optionally, I might also create a default team and
project for each new user on account creation just
so that the UX isn't hinky when folks try and register
their first model right out the gate.

There's a little bit of cleanup still needed around
both teams and projects (edit mutations, for example),
but I'll address those in later PRs and nothing there
is particularly urgent or needs unbreaking now
