### PR TITLE
Start fixing up auth

### DIFF
--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -4,7 +4,7 @@ import { HashBrown } from '../../utils/encryption.js';
 import { JWTValidator, PartialSession } from '../../utils/jwt.js';
 import { builder } from '../../builder.js';
 import { raw } from 'objection';
-import { convertSDL } from 'nexus';
+import { v4 as uuidv4 } from 'uuid';
 
 export const AccountInputType = builder.inputType('AccountInput', {
     fields: (t) => ({
@@ -86,12 +86,15 @@ builder.mutationFields((t) => ({
                 if (!verified) {
                     throw new AccountError({ name: 'LOGIN_ERROR' });
                 }
+                if (userAccount.isDisabled) {
+                    throw new AccountError({ name: 'DISABLED_ERROR' });
+                }
 
                 const partialSession = {
-                    dateCreated: Date.now(),
-                    userId: userAccount.$id(),
+                    jti: uuidv4(),
+                    sub: userAccount.$id(),
                 };
-                const token = JWT.encodeSession(partialSession);
+                const token = JWT.encodeSession(partialSession, 'access');
                 return token;
             });
             return results;

--- a/apollo/src/graphql/user/user.ts
+++ b/apollo/src/graphql/user/user.ts
@@ -111,3 +111,19 @@ export class ObjectionUserEmail extends Model {
         },
     });
 }
+
+export class ObjectionRefreshToken extends Model {
+    id!: number;
+    sessionId!: string;
+    sessionFamily!: string;
+    userId!: string;
+    isPartial!: boolean;
+    isRevoked!: boolean;
+    sessionIat!: string;
+    sessionExp!: string;
+
+    static tableName = 'dstkUser.refreshToken';
+    static get idColumn() {
+        return 'sessionId';
+    }
+}

--- a/apollo/src/utils/errors.ts
+++ b/apollo/src/utils/errors.ts
@@ -35,12 +35,19 @@ export class RegistryOperationError extends Error {
     }
 }
 
-type AccountErrorName = 'ACCOUNT_REGISTRATION_ERROR' | 'USERNAME_IN_USE_ERROR' | 'LOGIN_ERROR';
+type AccountErrorName = 
+    | 'ACCOUNT_REGISTRATION_ERROR'
+    | 'USERNAME_IN_USE_ERROR'
+    | 'LOGIN_ERROR'
+    | 'DISABLED_ERROR'
+    | 'INVALID_REFRESH_TOKEN';
 
 const AccountErrorMessages = {
     ACCOUNT_REGISTRATION_ERROR: 'Something went wrong and we were not able to complete this action',
     USERNAME_IN_USE_ERROR: 'An account already exists with this username',
     LOGIN_ERROR: 'The username or password supplied was incorrect',
+    DISABLED_ERROR: 'This account has been disabled',
+    INVALID_REFRESH_TOKEN: 'The refresh token provided was invalid. Please log in again',
 };
 
 export class AccountError extends Error {

--- a/apollo/src/utils/jwt.ts
+++ b/apollo/src/utils/jwt.ts
@@ -1,24 +1,37 @@
-import pkg from 'jsonwebtoken';
+import pkg, { JwtPayload } from 'jsonwebtoken';
+import { ObjectionRefreshToken } from '../graphql/user/user.js';
+import { AccountError } from './errors.js';
+import { v4 as uuidv4 } from 'uuid';
 const { sign, verify } = pkg;
 
 export interface Session {
-    dateCreated: number;
-    userId: string;
+    jti: string;
+    tokenFamily?: string;
+    sub: string;
     iat: number;
     exp: number;
 }
-export type PartialSession = Omit<Session, 'iat' | 'exp'>;
+
+export type PartialSession = Omit<Session, 'jti' | 'iat' | 'exp'>;
+
+type JwtType =
+    | 'refresh'
+    | 'access';
 
 export class JWTValidator {
     // again, obviously a placeholder until I get a proper secrets
     // manager implemented that can populate these values at runtime
     key: string = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 
-    encodeSession(partialSession: PartialSession): string {
+    encodeSession(partialSession: PartialSession, jwtType: JwtType): string {
         const issued = Date.now();
-        const expires = issued + 15 * 60 * 1000;
+
+        const fifteenMinutes = 15 * 60 * 1000;
+        const oneWeek = 7 * 24 * 60 * 60 * 1000;
+        const expires = (jwtType === 'refresh') ? issued + oneWeek : issued + fifteenMinutes;
         const session: Session = {
             ...partialSession,
+            jti: uuidv4(),
             iat: issued,
             exp: expires,
         };
@@ -29,11 +42,51 @@ export class JWTValidator {
         return signedJWT;
     }
 
-    verifySession(tokenString: string) {
+    async verifySession(tokenString: string, jwtType: JwtType) {
         const decoded = verify(tokenString, this.key, {
             algorithms: ['HS512'],
-            maxAge: '3h',
-        });
+            maxAge: (jwtType === 'access') ? '7 days' : undefined,
+        }) as JwtPayload;
+
+        if (jwtType === 'refresh') {
+            const userTokens = await ObjectionRefreshToken.query()
+                .where({ userId: decoded.sub });
+            const isRefreshTokenValid = userTokens.length > 0;
+
+            if (!isRefreshTokenValid) {
+                await ObjectionRefreshToken.query()
+                    .delete()
+                    .where({ sessionFamily: decoded.tokenFamily });
+                throw new AccountError({ name: 'INVALID_REFRESH_TOKEN' });
+            }
+        }
+
         return decoded;
     }
 }
+//     if (!isRefreshTokenValid) {
+//       await this.removeRefreshTokenFamilyIfCompromised(
+//         refreshTokenContent.sub,
+//         refreshTokenContent.tokenFamily,
+//       );
+
+//       throw new InvalidRefreshTokenException();
+//     }
+
+//     return true;
+//   }
+
+//   private async removeRefreshTokenFamilyIfCompromised(
+//     userId: string,
+//     tokenFamily: string,
+//   ): Promise<void> {
+//     const familyTokens = await this.prismaService.userTokens.findMany({
+//       where: { userId, family: tokenFamily },
+//     });
+
+//     if (familyTokens.length > 0) {
+//       await this.prismaService.userTokens.deleteMany({
+//         where: { userId, family: tokenFamily },
+//       });
+//     }
+//   }

--- a/postgres/patches/20230803_users.sql
+++ b/postgres/patches/20230803_users.sql
@@ -28,27 +28,27 @@ CREATE TABLE dstk_user.email (
     date_modified     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE dstk_user.session (
-    id              SERIAL      NOT NULL PRIMARY KEY,
-    session_id      UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
-    user_id         VARCHAR(16) NOT NULL REFERENCES dstk_user.user(user_id),
-    is_partial      BOOLEAN     NOT NULL,
-    session_key     VARCHAR(64) NOT NULL,
-    session_expires TIMESTAMP WITH TIME ZONE NOT NULL,
-    sesstion_start  TIMESTAMP WITH TIME ZONE NOT NULL
+CREATE TABLE dstk_user.refresh_token (
+    id             BIGSERIAL   NOT NULL PRIMARY KEY,
+    session_id     UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    session_family UUID        NOT NULL DEFAULT uuid_generate_v4(),
+    user_id        VARCHAR(16) NOT NULL REFERENCES dstk_user.user(user_id),
+    is_partial     BOOLEAN     NOT NULL DEFAULT TRUE,
+    is_revoked     BOOLEAN     NOT NULL DEFAULT FALSE,
+    session_iat    TIMESTAMP WITH TIME ZONE NOT NULL,
+    sesstion_exp   TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 CREATE TABLE dstk_user.log (
-    id            SERIAL NOT NULL PRIMARY KEY,
-    log_id        UUID   NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
+    id            BIGSERIAL   NOT NULL PRIMARY KEY,
+    log_id        UUID        NOT NULL DEFAULT uuid_generate_v4() UNIQUE,
     user_id       VARCHAR(16) NOT NULL REFERENCES dstk_user.user(user_id),
     actor_id      VARCHAR(16) NOT NULL REFERENCES dstk_user.user(user_id),
-    session_id    UUID   NOT NULL REFERENCES dstk_user.session(session_id),
-    old_value     TEXT   NOT NULL,
-    new_value     TEXT   NOT NULL,
-    remote_addr   INET   NOT NULL,
-    details       TEXT   NOT NULL,
-    user_action   TEXT   NOT NULL,
+    old_value     TEXT        NOT NULL,
+    new_value     TEXT        NOT NULL,
+    remote_addr   INET        NOT NULL,
+    details       TEXT        NOT NULL,
+    user_action   TEXT        NOT NULL,
     date_created  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     date_modified TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
This just starts to shore up the auth stuff a tiny
bit. The only impactful change here (from a client
perspective) is that Apollo is now returning an
Authorization header with a refreshed auth token
on successful requests.

Next steps will be to properly issue and track
refresh tokens
