### PR TITLE
Add Get ML Model Version By ID Query

### DIFF
--- a/apollo/src/graphql/model-version/modelVersionQueries.ts
+++ b/apollo/src/graphql/model-version/modelVersionQueries.ts
@@ -17,4 +17,20 @@ builder.queryFields((t) => ({
             return mlModelVersions;
         },
     }),
+    getMLModelVersion: t.field({
+        type: MLModelVersion,
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            modelVersionId: t.arg.string({ required: true }),
+        },
+        async resolve(_root, args, _ctx) {
+            const mlModelVersion = (await ObjectionMLModelVersion.query().findById(
+                args.modelVersionId,
+            )) as typeof MLModelVersion.$inferType;
+
+            return mlModelVersion;
+        },
+    }),
 }));


### PR DESCRIPTION
Going to start working on S3 functionality. The idea is for the S3 stuff to live on the page that is specific to the ml model version. So this PR adds a query to the schema where we can grab information about a specific model version by its ID.

Page will be something like:

![image](https://github.com/dstk-labs/dstk/assets/77359138/8dd50af4-be8c-4375-bde7-879793fd1556)
