### PR TITLE
Add Model Version Pagination

### DIFF
--- a/apollo/src/graphql/index.ts
+++ b/apollo/src/graphql/index.ts
@@ -1,12 +1,14 @@
 export * from './auth/authMutations.js';
 
 export * from './model/model.js';
+export * from './model/modelConnection.js';
+export * from './model/modelEdge.js';
 export * from './model/modelMutations.js';
 export * from './model/modelQueries.js';
 
 export * from './model-version/modelVersion.js';
-export * from './model/modelConnection.js';
-export * from './model/modelEdge.js';
+export * from './model-version/modelVersionConnection.js';
+export * from './model-version/modelVersionEdge.js';
 export * from './model-version/modelVersionMutations.js';
 export * from './model-version/modelVersionQueries.js';
 

--- a/apollo/src/graphql/model-version/modelVersionConnection.ts
+++ b/apollo/src/graphql/model-version/modelVersionConnection.ts
@@ -1,0 +1,29 @@
+import { builder } from '../../builder.js';
+import { PageInfo, PageInfoClass } from '../misc/pageInfo.js';
+import { MLModelVersionEdge, MLModelVersionEdgeClass } from './modelVersionEdge.js';
+
+export const MLModelVersionConnection = builder.objectRef<MLModelVersionConnectionClass>(
+    'MLModelVersionConnection',
+);
+
+builder.objectType(MLModelVersionConnection, {
+    fields: (t) => ({
+        edges: t.field({
+            type: [MLModelVersionEdge],
+            resolve(root, _args, _ctx) {
+                return root.edges;
+            },
+        }),
+        pageInfo: t.field({
+            type: PageInfo,
+            resolve(root, _args, _ctx) {
+                return root.pageInfo;
+            },
+        }),
+    }),
+});
+
+export class MLModelVersionConnectionClass {
+    edges!: MLModelVersionEdgeClass[];
+    pageInfo!: PageInfoClass;
+}

--- a/apollo/src/graphql/model-version/modelVersionEdge.ts
+++ b/apollo/src/graphql/model-version/modelVersionEdge.ts
@@ -1,0 +1,21 @@
+import { builder } from '../../builder.js';
+import { MLModelVersion, ObjectionMLModelVersion } from './modelVersion.js';
+
+export const MLModelVersionEdge = builder.objectRef<MLModelVersionEdgeClass>('MLModelVersionEdge');
+
+builder.objectType(MLModelVersionEdge, {
+    fields: (t) => ({
+        cursor: t.exposeString('cursor'),
+        node: t.field({
+            type: MLModelVersion,
+            async resolve(root, _args, _ctx) {
+                return await root.node;
+            },
+        }),
+    }),
+});
+
+export class MLModelVersionEdgeClass {
+    cursor!: string;
+    node!: ObjectionMLModelVersion;
+}

--- a/apollo/src/graphql/model-version/modelVersionQueries.ts
+++ b/apollo/src/graphql/model-version/modelVersionQueries.ts
@@ -1,20 +1,98 @@
 import { MLModelVersion, ObjectionMLModelVersion } from './modelVersion.js';
 import { builder } from '../../builder.js';
+import { MLModelVersionConnection } from './modelVersionConnection.js';
+import { ObjectionCursor } from '../metadata/cursor.js';
+import { Encoder } from '../../utils/encoder.js';
+import { CursorError } from '../../utils/errors.js';
+
+const encoder = new Encoder();
 
 builder.queryFields((t) => ({
     listMLModelVersions: t.field({
-        type: [MLModelVersion],
+        type: MLModelVersionConnection,
         authScopes: {
             loggedIn: true,
         },
         args: {
             modelId: t.arg.string({ required: true }),
+            // TODO: Putting defaultValue & required overrides defaultValue
+            first: t.arg({
+                type: 'Limit',
+                defaultValue: 10,
+                required: true,
+            }),
+            after: t.arg.string(),
         },
-        async resolve(root, args, ctx) {
-            const mlModelVersions = await ObjectionMLModelVersion.query()
-                .where('modelId', args.modelId)
-                .orderBy('numericVersion', 'ASC');
-            return mlModelVersions;
+        async resolve(_root, args, _ctx) {
+            const now = new Date(Date.now()).toISOString();
+            const nowPlusFiveMins = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+            const query = ObjectionMLModelVersion.query();
+
+            if (args.after) {
+                const cursor = await ObjectionCursor.query().findOne({
+                    cursorToken: args.after,
+                    cursorRelation: 'model_version',
+                });
+
+                /* This will always return true b/c we do not have a scheduled
+                   system inplace to delete expired tokens. */
+                if (cursor) {
+                    if (cursor.expiration <= now) {
+                        await cursor.$query().patch({ expiration: nowPlusFiveMins });
+                    }
+
+                    const [id, numericVersion] = encoder.decode(cursor.cursorToken);
+
+                    query.where('numericVersion', '>', numericVersion).andWhere('id', '>', id);
+                } else {
+                    throw new CursorError({ name: 'TOKEN_DOES_NOT_EXIST' });
+                }
+            }
+
+            const mlModelVersions = await query
+                .where('modelId', '=', args.modelId)
+                .limit(args.first + 1)
+                .orderBy(['numericVersion', 'id']);
+
+            const hasPreviousPage = !!args.after;
+            const hasNextPage = mlModelVersions.length > 1 && mlModelVersions.length > args.first;
+            const edges = mlModelVersions.slice(0, args.first);
+
+            const lastResult = edges[edges.length - 1];
+
+            const cursor =
+                edges.length > 0
+                    ? await ObjectionCursor.query().findOne({
+                          cursorRelation: 'model_version',
+                          cursorToken: encoder.encode(lastResult.id, lastResult.numericVersion),
+                      })
+                    : undefined;
+
+            const result = cursor
+                ? await cursor.$query().patchAndFetch({ expiration: nowPlusFiveMins })
+                : edges.length > 0
+                ? await ObjectionCursor.query().insertAndFetch({
+                      cursorToken: encoder.encode(
+                          edges[edges.length - 1].id,
+                          edges[edges.length - 1].numericVersion,
+                      ),
+                      cursorRelation: 'model_version',
+                  })
+                : undefined;
+
+            const continuationToken = result?.cursorToken;
+
+            return {
+                edges: edges.map((mlModelVersion) => ({
+                    cursor: encoder.encode(mlModelVersion.id, mlModelVersion.numericVersion),
+                    node: mlModelVersion,
+                })),
+                pageInfo: {
+                    hasPreviousPage: hasPreviousPage,
+                    hasNextPage: hasNextPage,
+                    continuationToken: continuationToken,
+                },
+            };
         },
     }),
     getMLModelVersion: t.field({


### PR DESCRIPTION
Adds the ability paginate the ML Model Versions. Follows the same principles as the ML Model pagination, except that the cursor uses the numeric version instead of the created at date.