### PR TITLE
Associate models/storage providers to teams

### DIFF
--- a/apollo/src/graphql/model/model.ts
+++ b/apollo/src/graphql/model/model.ts
@@ -3,6 +3,7 @@ import { Model } from 'objection';
 import { StorageProvider, ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
 import { MLModelVersion, ObjectionMLModelVersion } from '../model-version/modelVersion.js';
 import { User, ObjectionUser } from '../user/user.js';
+import { ObjectionProject, Project } from '../user/project.js';
 
 export const MLModel = builder.objectRef<ObjectionMLModel>('MLModel');
 
@@ -20,7 +21,7 @@ builder.objectType(MLModel, {
             async resolve(root: ObjectionMLModel, _args, _ctx) {
                 const storageProvider = (await ObjectionStorageProvider.query()
                     .findById(root.storageProviderId)
-                    .first()) as typeof StorageProvider.$inferType;
+                    .first()) as ObjectionStorageProvider;
                 return storageProvider;
             },
         }),
@@ -30,7 +31,18 @@ builder.objectType(MLModel, {
             async resolve(root: ObjectionMLModel, _args, _ctx) {
                 const currentModelVersion = (await ObjectionMLModelVersion.query()
                     .findById(root.currentModelVersionId)
-                    .first()) as typeof MLModelVersion.$inferType;
+                    .first()) as ObjectionMLModelVersion;
+
+                return currentModelVersion;
+            },
+        }),
+
+        project: t.field({
+            type: Project,
+            async resolve(root: ObjectionMLModel, _args, _ctx) {
+                const currentModelVersion = (await ObjectionProject.query()
+                    .findById(root.projectId)
+                    .first()) as ObjectionProject;
 
                 return currentModelVersion;
             },
@@ -68,6 +80,7 @@ export class ObjectionMLModel extends Model {
     id!: number;
     storageProviderId!: string;
     currentModelVersionId!: string;
+    projectId!: string;
     isArchived!: boolean;
     modelName!: string;
     createdById!: string;

--- a/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -55,6 +55,7 @@ builder.objectType(StorageProvider, {
                 return user;
             },
         }),
+        teamId: t.exposeString('teamId'),
         dateCreated: t.exposeString('dateCreated'),
         dateModified: t.exposeString('dateModified'),
         isArchived: t.exposeBoolean('isArchived'),
@@ -71,6 +72,7 @@ export class ObjectionStorageProvider extends Model {
     createdById!: string;
     modifiedById!: string;
     ownerId!: string;
+    teamId!: string;
     dateCreated!: string;
     dateModified!: string;
     isArchived!: boolean;

--- a/apollo/src/graphql/user/team.ts
+++ b/apollo/src/graphql/user/team.ts
@@ -4,6 +4,7 @@ import { User, ObjectionUser } from '../user/user.js';
 import { ObjectionEdge } from '../misc/edges.js';
 import { RegistryOperationError } from '../../utils/errors.js';
 import { ObjectionProject } from './project.js';
+import { ObjectionStorageProvider } from '../storage-provider/storageProvider.js';
 
 export const Team = builder.objectRef<ObjectionTeam>('Team');
 
@@ -89,8 +90,8 @@ export class ObjectionTeam extends Model {
             join: {
                 from: 'dstkUser.teams.teamId',
                 through: {
-                    from: 'dstkUser.team_edges.teamId',
-                    to: 'dstkUser.team_edges.userId'
+                    from: 'dstkUser.teamEdges.teamId',
+                    to: 'dstkUser.teamEdges.userId'
                 },
                 to: 'dstkUser.user.userId',
             },
@@ -101,6 +102,14 @@ export class ObjectionTeam extends Model {
             join: {
                 from: 'dstkUser.teams.teamId',
                 to: 'dstkUser.projects.teamId',
+            },
+        },
+        storageProviders: {
+            relation: Model.HasManyRelation,
+            modelClass: ObjectionStorageProvider,
+            join: {
+                from: 'dstkUser.teams.teamId',
+                to: 'registry.storageProviders.teamId'
             },
         },
     });

--- a/apollo/src/utils/errors.ts
+++ b/apollo/src/utils/errors.ts
@@ -1,5 +1,6 @@
 type RegistryErrorName =
     | 'ARCHIVED_STORAGE_ERROR'
+    | 'PROVIDER_NOT_FOUND_ERROR'
     | 'ARCHIVED_MODEL_ERROR'
     | 'ARCHIVED_MODEL_VERSION_ERROR'
     | 'PUBLISHED_MODEL_VERSION_ERROR'
@@ -11,6 +12,8 @@ type RegistryErrorName =
 
 const RegistryErrorMessages = {
     ARCHIVED_STORAGE_ERROR: 'New model versions cannot be added to an archived storage provider',
+    PROVIDER_NOT_FOUND_ERROR:
+        "Either this storage provider doesn't exist or you don't have permission to take that action",
     ARCHIVED_MODEL_ERROR: 'New model versions cannot be added to archived models',
     ARCHIVED_MODEL_VERSION_ERROR: 'An archived model version cannot be modified',
     PUBLISHED_MODEL_VERSION_ERROR: 'Published model versions cannot be modified',

--- a/postgres/patches/20240113_model-project-association.sql
+++ b/postgres/patches/20240113_model-project-association.sql
@@ -1,0 +1,4 @@
+\connect dstk;
+
+ALTER TABLE registry.models
+ADD COLUMN project_id UUID NOT NULL REFERENCES dstk_user.projects(project_id);

--- a/postgres/patches/20240113_storage-provider-team-association.sql
+++ b/postgres/patches/20240113_storage-provider-team-association.sql
@@ -1,0 +1,4 @@
+\connect dstk;
+
+ALTER TABLE registry.storage_providers
+ADD COLUMN team_id UUID NOT NULL REFERENCES dstk_user.teams(team_id);


### PR DESCRIPTION
This adds associations back to projects/teams for
both models and storage providers. A storage provider
must now be created at the team level, and can only
be accessed by objects under that team scope. A
model must now be created at the project level,
and can only be created by a user with write access
on the parent team.

As todos coming out of this PR, I will need to still:

  - [ ] Fix up the edit method for storage providers
  - [x] Enforce policy checks on all model edit and query
        methods
  - [ ] Enforce policy checks on all model version mutations
        and queries
  - [ ] Enforce policy checks on all storage provider queries
        and the remaining mutations
