### PR TITLE
Add listObjectsForModelVersion Query

### DIFF
--- a/apollo/src/graphql/index.ts
+++ b/apollo/src/graphql/index.ts
@@ -14,6 +14,9 @@ export * from './model-version/modelVersionQueries.js';
 
 export * from './storage-provider/storageProvider.js';
 export * from './storage-provider/storageProviderMutations.js';
+export * from './storage-provider/storageProviderObject.js';
+export * from './storage-provider/storageProviderObjectConnection.js';
+export * from './storage-provider/storageProviderObjectEdge.js';
 export * from './storage-provider/storageProviderQueries.js';
 
 export * from './user/user.js';

--- a/apollo/src/graphql/model/model.ts
+++ b/apollo/src/graphql/model/model.ts
@@ -148,7 +148,7 @@ export class ObjectionMLModel extends Model {
             },
         },
         getTeam: {
-            relation: Model.BelongsToOneRelation,
+            relation: Model.HasOneThroughRelation,
             modelClass: ObjectionTeam,
             join: {
                 from: 'registry.models.projectId',

--- a/apollo/src/graphql/storage-provider/storageProviderObject.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderObject.ts
@@ -1,7 +1,7 @@
 import { builder } from '../../builder.js';
 
 export const StorageProviderObjectType = builder.enumType('StorageProviderObjectType', {
-    values: ['folder', 'file', 'viewer'] as const,
+    values: ['folder', 'file'] as const,
 });
 
 export const StorageProviderObject =

--- a/apollo/src/graphql/storage-provider/storageProviderObject.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderObject.ts
@@ -1,21 +1,10 @@
 import { builder } from '../../builder.js';
 
-export const StorageProviderObjectType = builder.enumType('StorageProviderObjectType', {
-    values: ['folder', 'file'] as const,
-});
-
 export const StorageProviderObject =
     builder.objectRef<StorageProviderObjectClass>('StorageProviderObject');
 
 builder.objectType(StorageProviderObject, {
     fields: (t) => ({
-        id: t.field({
-            type: 'String',
-            nullable: true,
-            resolve(root, _args, _ctx) {
-                return root.id;
-            },
-        }),
         name: t.field({
             type: 'String',
             nullable: true,
@@ -37,20 +26,11 @@ builder.objectType(StorageProviderObject, {
                 return root.lastModified;
             },
         }),
-        type: t.field({
-            type: StorageProviderObjectType,
-            nullable: true,
-            resolve(root, _args, _ctx) {
-                return root.type;
-            },
-        }),
     }),
 });
 
 export class StorageProviderObjectClass {
-    id?: string;
     name?: string;
     size?: number;
     lastModified?: string;
-    type?: 'file' | 'folder';
 }

--- a/apollo/src/graphql/storage-provider/storageProviderObject.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderObject.ts
@@ -1,0 +1,56 @@
+import { builder } from '../../builder.js';
+
+export const StorageProviderObjectType = builder.enumType('StorageProviderObjectType', {
+    values: ['folder', 'file', 'viewer'] as const,
+});
+
+export const StorageProviderObject =
+    builder.objectRef<StorageProviderObjectClass>('StorageProviderObject');
+
+builder.objectType(StorageProviderObject, {
+    fields: (t) => ({
+        id: t.field({
+            type: 'String',
+            nullable: true,
+            resolve(root, _args, _ctx) {
+                return root.id;
+            },
+        }),
+        name: t.field({
+            type: 'String',
+            nullable: true,
+            resolve(root, _args, _ctx) {
+                return root.name;
+            },
+        }),
+        size: t.field({
+            type: 'Int',
+            nullable: true,
+            resolve(root, _args, _ctx) {
+                return root.size;
+            },
+        }),
+        lastModified: t.field({
+            type: 'String',
+            nullable: true,
+            resolve(root, _args, _ctx) {
+                return root.lastModified;
+            },
+        }),
+        type: t.field({
+            type: StorageProviderObjectType,
+            nullable: true,
+            resolve(root, _args, _ctx) {
+                return root.type;
+            },
+        }),
+    }),
+});
+
+export class StorageProviderObjectClass {
+    id?: string;
+    name?: string;
+    size?: number;
+    lastModified?: string;
+    type?: 'file' | 'folder';
+}

--- a/apollo/src/graphql/storage-provider/storageProviderObjectConnection.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderObjectConnection.ts
@@ -1,0 +1,31 @@
+import { builder } from '../../builder.js';
+import { PageInfo, PageInfoClass } from '../misc/pageInfo.js';
+import {
+    StorageProviderObjectEdge,
+    StorageProviderObjectEdgeClass,
+} from './storageProviderObjectEdge.js';
+
+export const StorageProviderObjectConnection =
+    builder.objectRef<StorageProviderObjectConnectionClass>('StorageProviderObjectConnection');
+
+builder.objectType(StorageProviderObjectConnection, {
+    fields: (t) => ({
+        edges: t.field({
+            type: [StorageProviderObjectEdge],
+            resolve(root, _args, _ctx) {
+                return root.edges;
+            },
+        }),
+        pageInfo: t.field({
+            type: PageInfo,
+            resolve(root, _args, _ctx) {
+                return root.pageInfo;
+            },
+        }),
+    }),
+});
+
+export class StorageProviderObjectConnectionClass {
+    edges!: StorageProviderObjectEdgeClass[];
+    pageInfo!: PageInfoClass;
+}

--- a/apollo/src/graphql/storage-provider/storageProviderObjectEdge.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderObjectEdge.ts
@@ -1,0 +1,23 @@
+import { builder } from '../../builder.js';
+import { StorageProviderObject, StorageProviderObjectClass } from './storageProviderObject.js';
+
+export const StorageProviderObjectEdge = builder.objectRef<StorageProviderObjectEdgeClass>(
+    'StorageProviderObjectEdge',
+);
+
+builder.objectType(StorageProviderObjectEdge, {
+    fields: (t) => ({
+        cursor: t.exposeString('cursor'),
+        node: t.field({
+            type: StorageProviderObject,
+            async resolve(root, _args, _ctx) {
+                return await root.node;
+            },
+        }),
+    }),
+});
+
+export class StorageProviderObjectEdgeClass {
+    cursor!: string;
+    node!: StorageProviderObjectClass;
+}

--- a/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -91,11 +91,13 @@ builder.queryFields((t) => ({
             );
 
             const objects = Contents
-                ? Contents.map((Content) => ({
-                      name: Content.Key,
-                      size: Content.Size,
-                      lastModified: Content.LastModified && Content.LastModified.toISOString(),
-                  })).filter((Content) => Content.name?.slice(0, -1) !== Prefix)
+                ? Contents.filter((Content) => Content.Key?.slice(0, -1) !== Prefix).map(
+                      (Content) => ({
+                          name: Content.Key && Content.Key.replace(prefix + '/', ''),
+                          size: Content.Size,
+                          lastModified: Content.LastModified && Content.LastModified.toISOString(),
+                      }),
+                  )
                 : [];
 
             return {

--- a/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -47,22 +47,6 @@ builder.queryFields((t) => ({
             prefix: t.arg.string(),
         },
         async resolve(_root, args, _ctx) {
-            const splitKey = (prefixLength: number, objectKey?: string): string[] => {
-                if (objectKey) {
-                    return objectKey.slice(prefixLength + 1).split('/');
-                }
-
-                return [];
-            };
-
-            const folderOrFile = (keyArr?: string[]): 'folder' | 'file' | undefined => {
-                if (keyArr) {
-                    return keyArr.length > 1 ? 'folder' : 'file';
-                }
-
-                return undefined;
-            };
-
             const modelStorageProvider = (await ObjectionMLModelVersion.relatedQuery(
                 'storageProvider',
             )
@@ -92,20 +76,12 @@ builder.queryFields((t) => ({
                 maxKeys,
             );
 
-            const prefixLength = prefix.length;
-
             const objects = Contents
                 ? Contents.map((Content) => ({
-                      id: Content.Key,
-                      name:
-                          Content.Key &&
-                          folderOrFile(splitKey(prefix.length, Content.Key)) === 'folder'
-                              ? splitKey(prefixLength, Content.Key)[0]
-                              : splitKey(prefixLength, Content.Key).at(-1),
+                      name: Content.Key,
                       size: Content.Size,
                       lastModified: Content.LastModified && Content.LastModified.toISOString(),
-                      type: folderOrFile(splitKey(prefixLength, Content.Key)),
-                  })).filter((Content) => Content.id?.slice(0, -1) !== Prefix)
+                  })).filter((Content) => Content.name?.slice(0, -1) !== Prefix)
                 : [];
 
             return {

--- a/apollo/src/utils/s3-api.ts
+++ b/apollo/src/utils/s3-api.ts
@@ -3,6 +3,7 @@ import {
     AbortMultipartUploadCommand,
     CompleteMultipartUploadCommand,
     CreateMultipartUploadCommand,
+    ListObjectsV2Command,
     S3Client,
     UploadPartCommand,
 } from '@aws-sdk/client-s3';
@@ -126,5 +127,32 @@ export async function AbortMultipartUpload(
         UploadId: uploadId,
     });
     const response = client.send(command);
+    return response;
+}
+
+export async function ListObjects(
+    storageProvider: ObjectionStorageProvider,
+    maxKeys: number,
+    prefix: string,
+    continuationToken?: string,
+) {
+    const client = new S3Client({
+        apiVersion: '2006-03-01',
+        region: storageProvider.region,
+        endpoint: storageProvider.endpointUrl,
+        credentials: {
+            accessKeyId: EncryptoMatic.decrypt(storageProvider.accessKeyId),
+            secretAccessKey: EncryptoMatic.decrypt(storageProvider.secretAccessKey),
+        },
+    });
+
+    const command = new ListObjectsV2Command({
+        Bucket: storageProvider.bucket,
+        ContinuationToken: continuationToken,
+        MaxKeys: maxKeys,
+        Prefix: prefix,
+    });
+
+    const response = await client.send(command);
     return response;
 }


### PR DESCRIPTION
Closes #68 

Adds a `listObjectsForModelVersion` query that returns the contents of a storage provider for a particular model version. We also leverage the built in S3 pagination spec to conform to our "kind of sort of" Relay Cursor Spec that our API is using (which I may or may not jokingly refer to as the DSTK Cursor Spec from now on).

The query takes in four arguments:
  - `modelVersionId`
    - Required
    - Looks up the contents in the storage provider based on this model version. Important to note that we are using a `DEFAULT` team delimiter at the moment, so this will change in a future PR.
- `after`
  - Optional
  - Corresponds to the `NextContinuationToken` returned from the S3 API.
- `prefix`
  - Optional. If not supplied, refers to the root directory of the model version bucket.
  - If supplied, the prefix is appended onto the root directory so that the consumers of the API can mimic going through an actual file system.
- `first`
  - Defaults to 10. Same as the other `first` input arguments used in the DSTK Cursor Spec

Some Fun Notes that you can totally inquire on:
- The logic used in the `listObjectsForModelVersion` is slightly janky because the S3 API has `undefined` attached to everything that it can return. This causes the Pothos type inference system to be annoyed. I tried to leave appropriate comments where possible when addressing this.
- The S3 API treats EVERYTHING as an object, meaning there is no real concepts of "folders". On the client, we want to provide an actual file browser experience, so I have some functions set up that helps differentiate what should be considered a file and what should be considered a directory.
- If no continuation token is set, the S3 API will always return the root directory as an object. This means nothing for what we plan on using this query for, so we remove the root directory from the response. As a result, we have to grab `LIMIT + 1` if removing the root directory cause otherwise the expected response will always be one short.