### PR TITLE
Add List Users Query

### DIFF
--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -1,5 +1,6 @@
 import { builder } from '../../builder.js';
 import { ApiKey, ObjectionApiKey } from '../auth/auth.js';
+import { ObjectionUser, User } from './user.js';
 
 builder.queryFields((t) => ({
     listApiKeys: t.field({
@@ -13,6 +14,16 @@ builder.queryFields((t) => ({
                 isArchived: false,
             });
             return apiKeys;
+        },
+    }),
+    listUsers: t.field({
+        type: [User],
+        authScopes: {
+            loggedIn: true,
+        },
+        async resolve(_root, _args, _ctx) {
+            const users = await ObjectionUser.query().orderBy('userName');
+            return users;
         },
     }),
 }));

--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -1,5 +1,6 @@
 import { builder } from '../../builder.js';
 import { ApiKey, ObjectionApiKey } from '../auth/auth.js';
+import { ObjectionTeamEdge } from './team.js';
 import { ObjectionUser, User } from './user.js';
 
 builder.queryFields((t) => ({
@@ -21,7 +22,12 @@ builder.queryFields((t) => ({
         authScopes: {
             loggedIn: true,
         },
-        async resolve(_root, _args, _ctx) {
+        args: {
+            teamId: t.arg.string({ required: true }),
+        },
+        async resolve(_root, args, ctx) {
+            await ObjectionTeamEdge.userHasRole(ctx.user.$id(), args.teamId, ['owner']);
+
             const users = await ObjectionUser.query().orderBy('userName');
             return users;
         },

--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -28,9 +28,7 @@ builder.queryFields((t) => ({
         async resolve(_root, args, ctx) {
             await ObjectionTeamEdge.userHasRole(ctx.user.$id(), args.teamId, ['owner']);
 
-            const users = await ObjectionUser.query()
-                .where('isApproved', '=', true)
-                .orderBy('userName');
+            const users = await ObjectionUser.query().orderBy('userName');
             return users;
         },
     }),

--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -1,6 +1,5 @@
 import { builder } from '../../builder.js';
 import { ApiKey, ObjectionApiKey } from '../auth/auth.js';
-import { ObjectionTeamEdge } from './team.js';
 import { ObjectionUser, User } from './user.js';
 
 builder.queryFields((t) => ({
@@ -22,12 +21,7 @@ builder.queryFields((t) => ({
         authScopes: {
             loggedIn: true,
         },
-        args: {
-            teamId: t.arg.string({ required: true }),
-        },
-        async resolve(_root, args, ctx) {
-            await ObjectionTeamEdge.userHasRole(ctx.user.$id(), args.teamId, ['owner']);
-
+        async resolve(_root, _args, _ctx) {
             const users = await ObjectionUser.query().orderBy('userName');
             return users;
         },

--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -28,7 +28,9 @@ builder.queryFields((t) => ({
         async resolve(_root, args, ctx) {
             await ObjectionTeamEdge.userHasRole(ctx.user.$id(), args.teamId, ['owner']);
 
-            const users = await ObjectionUser.query().orderBy('userName');
+            const users = await ObjectionUser.query()
+                .where('isApproved', '=', true)
+                .orderBy('userName');
             return users;
         },
     }),


### PR DESCRIPTION
Adds a method that lists all verified users. Since users with an owner role are the only ones who are allowed to add a member to a team, this query is only accessible to owners of a team.

This query was added so that we have a method to get a user's ID to use in the `addToTeam` mutation.