### PR TITLE
Add getUser Query

### DIFF
--- a/apollo/src/graphql/user/userQueries.ts
+++ b/apollo/src/graphql/user/userQueries.ts
@@ -39,4 +39,15 @@ builder.queryFields((t) => ({
             return users;
         },
     }),
+    getUser: t.field({
+        type: User,
+        async resolve(_root, _args, ctx) {
+            const user = await db
+                .selectFrom('dstk_user.user')
+                .selectAll()
+                .where('dstk_user.user.user_id', '=', ctx.user.user_id)
+                .executeTakeFirst();
+            return user;
+        },
+    }),
 }));


### PR DESCRIPTION
This PR adds a new query called `getUser` which returns the currently logged in user. This query can be used by frontend / sdk clients to check if a user is signed in or not.