### PR TITLE
Add Automatic Personal Team Creation on Register

### DIFF
--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -68,7 +68,7 @@ builder.mutationFields((t) => ({
                 .executeTakeFirstOrThrow();
             
             await createTeam({
-                description: 'Your private team. Automatically created by DSTK.',
+                description: `${user.user_name}'s private team. Automatically created by DSTK.`,
                 name: 'Personal Team',
                 userId: user.user_id,
             });

--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -3,6 +3,7 @@ import { auth } from '../../utils/auth.js';
 import { User } from '../user/user.js';
 import { db } from '../../db/kysely.js';
 import { AccountError } from '../../utils/errors.js';
+import { createTeam } from '../../utils/teamUtils.js';
 
 export const AccountInputType = builder.inputType('AccountInput', {
     fields: (t) => ({
@@ -65,6 +66,12 @@ builder.mutationFields((t) => ({
                 .selectAll()
                 .where('dstk_user.user.id', '=', response.user.id)
                 .executeTakeFirstOrThrow();
+            
+            await createTeam({
+                description: 'Your private team. Automatically created by DSTK.',
+                name: 'Personal Team',
+                userId: user.user_id,
+            });
 
             return user;
         },

--- a/apollo/src/graphql/user/teamMutations.ts
+++ b/apollo/src/graphql/user/teamMutations.ts
@@ -2,6 +2,7 @@ import { builder } from '../../builder.js';
 import { db } from '../../db/kysely.js';
 import { RegistryOperationError } from '../../utils/errors.js';
 import { userHasRole } from '../../utils/rls.js';
+import { createTeam } from '../../utils/teamUtils.js';
 import { Team } from './team.js';
 
 export const TeamInputType = builder.inputType('TeamInput', {
@@ -36,36 +37,13 @@ builder.mutationFields((t) => ({
             data: t.arg({ type: TeamInputType, required: true }),
         },
         async resolve(_root, args, ctx) {
-            const results = await db.transaction().execute(async (trx) => {
-                const team = await trx
-                    .insertInto('dstk_user.teams')
-                    .values({
-                        name: args.data.name,
-                        description: args.data.description,
-                        created_by_id: ctx.user.user_id,
-                        modified_by_id: ctx.user.user_id,
-                    })
-                    .returningAll()
-                    .executeTakeFirstOrThrow();
-
-                const ownerEdgeType = await trx
-                    .selectFrom('dstk_metadata.edge_relations')
-                    .select('dstk_metadata.edge_relations.id')
-                    .where('dstk_metadata.edge_relations.type', '=', 'owner')
-                    .executeTakeFirstOrThrow();
-
-                await trx
-                    .insertInto('dstk_user.team_edges')
-                    .values({
-                        team_id: team.team_id,
-                        user_id: ctx.user.user_id,
-                        edge_type: ownerEdgeType.id,
-                    })
-                    .execute();
-
-                return team;
+            const team = await createTeam({
+                description: args.data.description,
+                name: args.data.name,
+                userId: ctx.user.user_id,
             });
-            return results;
+
+            return team;
         },
     }),
     addToTeam: t.boolean({

--- a/apollo/src/graphql/user/teamQueries.ts
+++ b/apollo/src/graphql/user/teamQueries.ts
@@ -30,6 +30,10 @@ builder.queryFields((t) => ({
                     return eb.and(ands);
                 })
                 .execute();
+            
+            if (userTeamEdges.length === 0) {
+                return [];
+            }
 
             const userTeams = await db
                 .selectFrom('dstk_user.teams')

--- a/apollo/src/utils/teamUtils.ts
+++ b/apollo/src/utils/teamUtils.ts
@@ -1,0 +1,44 @@
+import { db } from "../db/kysely.js";
+
+type CreateTeam = {
+    description: string;
+    name: string;
+    userId: string;
+}
+
+export const createTeam = async ({
+    description,
+    name,
+    userId,
+}: CreateTeam) => {
+    const results = await db.transaction().execute(async (trx) => {
+        const team = await trx
+            .insertInto('dstk_user.teams')
+            .values({
+                name,
+                description,
+                created_by_id: userId,
+                modified_by_id: userId,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow();
+
+        const ownerEdgeType = await trx
+            .selectFrom('dstk_metadata.edge_relations')
+            .select('dstk_metadata.edge_relations.id')
+            .where('dstk_metadata.edge_relations.type', '=', 'owner')
+            .executeTakeFirstOrThrow();
+
+        await trx
+            .insertInto('dstk_user.team_edges')
+            .values({
+                team_id: team.team_id,
+                user_id: userId,
+                edge_type: ownerEdgeType.id,
+            })
+            .execute();
+
+        return team;
+    });
+    return results;
+};

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",
-    "zod": "^3.25.53"
+    "zod": "^3.25.53",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   zod:
     specifier: ^3.25.53
     version: 3.25.56
+  zustand:
+    specifier: ^5.0.5
+    version: 5.0.5(@types/react@19.1.6)(react@19.1.0)
 
 devDependencies:
   '@eslint/js':
@@ -4764,4 +4767,26 @@ packages:
 
   /zod@3.25.56:
     resolution: {integrity: sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==}
+    dev: false
+
+  /zustand@5.0.5(@types/react@19.1.6)(react@19.1.0):
+    resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+    dependencies:
+      '@types/react': 19.1.6
+      react: 19.1.0
     dev: false

--- a/web/src/features/teams/loaders/teamsLoader.ts
+++ b/web/src/features/teams/loaders/teamsLoader.ts
@@ -1,10 +1,11 @@
 import { gql } from '@/graphql';
 import { preloadQuery } from '@/lib/apollo';
 
-const LIST_TEAMS = gql(`
+export const LIST_TEAMS = gql(`
     query ListTeams {
         listTeams {
             name
+            teamId
         }
     }`);
 

--- a/web/src/layouts/dashboard/TeamSelect.tsx
+++ b/web/src/layouts/dashboard/TeamSelect.tsx
@@ -1,8 +1,10 @@
 import { PreloadedQueryRef, useReadQuery } from '@apollo/client';
 import { Select } from '@mantine/core';
+import { useEffect } from 'react';
 import { useRouteLoaderData } from 'react-router';
 
 import { ListTeamsQuery } from '@/graphql/graphql';
+import { useTeamStore } from '@/stores/teamStore';
 
 export const TeamSelect = () => {
   const queryRef = useRouteLoaderData('dashboard') as PreloadedQueryRef<
@@ -11,11 +13,31 @@ export const TeamSelect = () => {
   >;
   const { data } = useReadQuery(queryRef);
 
+  const { selectedTeam, setSelectedTeam } = useTeamStore();
+
+  useEffect(() => {
+    if (data?.listTeams) {
+      const personalTeam = data.listTeams.find(
+        (team) => team.name === 'Personal Team',
+      );
+      if (personalTeam && personalTeam.teamId) {
+        setSelectedTeam(personalTeam.teamId);
+      }
+    }
+  }, [data.listTeams, selectedTeam, setSelectedTeam]);
+
   return (
     <Select
-      data={data.listTeams?.map((team) => team.name ?? '')}
+      data={data.listTeams?.map((team) => ({
+        label: team.name ?? '',
+        value: team.teamId ?? '',
+      }))}
       mb='sm'
+      onChange={(value) => {
+        if (value) setSelectedTeam(value);
+      }}
       size='sm'
+      value={selectedTeam}
     />
   );
 };

--- a/web/src/pages/auth/login/loginPage.tsx
+++ b/web/src/pages/auth/login/loginPage.tsx
@@ -20,6 +20,7 @@ import { GithubIcon } from '@/components/icons/github/GithubIcon';
 import { GoogleIcon } from '@/components/icons/google/GoogleIcon';
 import { paths } from '@/config/paths';
 import { GET_USER } from '@/features/auth/loaders/authLoader';
+import { LIST_TEAMS } from '@/features/teams/loaders/teamsLoader';
 import { gql } from '@/graphql';
 
 import styles from './LoginPage.module.css';
@@ -57,7 +58,7 @@ export const LoginPage = () => {
 
   const onSubmit = (values: LoginSchema) =>
     login({
-      refetchQueries: [{ query: GET_USER }],
+      refetchQueries: [{ query: GET_USER }, { query: LIST_TEAMS }],
       variables: {
         data: { ...values },
       },

--- a/web/src/pages/auth/register/RegisterForm.tsx
+++ b/web/src/pages/auth/register/RegisterForm.tsx
@@ -18,6 +18,7 @@ import type { AccountInput } from '@/graphql/types';
 import { GithubIcon } from '@/components/icons/github/GithubIcon';
 import { GoogleIcon } from '@/components/icons/google/GoogleIcon';
 import { GET_USER } from '@/features/auth/loaders/authLoader';
+import { LIST_TEAMS } from '@/features/teams/loaders/teamsLoader';
 import { gql } from '@/graphql';
 
 import styles from './RegisterForm.module.css';
@@ -115,7 +116,7 @@ export const RegisterForm = () => {
 
   const onSubmit = (values: RegisterSchema) =>
     register({
-      refetchQueries: [{ query: GET_USER }],
+      refetchQueries: [{ query: GET_USER }, { query: LIST_TEAMS }],
       variables: {
         data: {
           email: values.email,

--- a/web/src/stores/teamStore.ts
+++ b/web/src/stores/teamStore.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+export const useTeamStore = create<{
+  selectedTeam: null | string;
+  setSelectedTeam: (id: string) => void;
+}>((set) => ({
+  selectedTeam: localStorage.getItem('dstkSelectedTeam'),
+  setSelectedTeam: (id) => {
+    localStorage.setItem('dstkSelectedTeam', id);
+    set({ selectedTeam: id });
+  },
+}));


### PR DESCRIPTION
This PR adds a feature that creates a personal team for a user on registration. On registration, the user will be assigned the owner of a team with the following characteristics:
  - Name: Personal Team
  - Description: Your private team. Automatically created by DSTK

I stink at naming things, so feel free to yell at me about the above choice.

On the frontend, we added a local storage variable called `dstkSelectedTeam`. This variable keeps track of the Team ID of the selected team from the dashboard. We also add a check that if this variable is `null`, then we automatically assign it to the user's personal team.

Finally, added a fix to the `listTeams` query. If the length of the `userTeamEdges` result was zero, Kysely would throw a syntax error in the following DB call. We add a check that if `userTeamEdges.length === 0`, then we return an empty array from the query.