### PR TITLE
Add Project Name and Status as Arguments to List Projects Query

### DIFF
--- a/apollo/src/graphql/misc/status.ts
+++ b/apollo/src/graphql/misc/status.ts
@@ -1,5 +1,0 @@
-import { builder } from "../../builder.js";
-
-export const Status = builder.enumType('Status', {
-    values: ['ALL', 'ARCHIVED_ONLY', 'ACTIVE_ONLY'] as const,
-});

--- a/apollo/src/graphql/misc/status.ts
+++ b/apollo/src/graphql/misc/status.ts
@@ -1,0 +1,5 @@
+import { builder } from "../../builder.js";
+
+export const Status = builder.enumType('Status', {
+    values: ['ALL', 'ARCHIVED_ONLY', 'ACTIVE_ONLY'] as const,
+});

--- a/apollo/src/graphql/user/projectQueries.ts
+++ b/apollo/src/graphql/user/projectQueries.ts
@@ -4,7 +4,6 @@ import { RegistryOperationError } from '../../utils/errors.js';
 import { userHasRole } from '../../utils/rls.js';
 import { db } from '../../db/kysely.js';
 import type { Expression, SqlBool } from 'kysely';
-import { Status } from '../misc/status.js';
 
 builder.queryFields((t) => ({
     listProjects: t.field({
@@ -13,12 +12,8 @@ builder.queryFields((t) => ({
             loggedIn: true,
         },
         args: {
+            includeArchived: t.arg.boolean({ required: true, defaultValue: false }),
             projectName: t.arg.string(),
-            projectStatus: t.arg({
-                type: Status,
-                required: true,
-                defaultValue: 'ALL',
-            }),
             teamId: t.arg.string({ required: true }),
         },
         async resolve(_root, args, ctx) {
@@ -38,15 +33,9 @@ builder.queryFields((t) => ({
                         'dstk_user.projects.team_id', '=', args.teamId,
                     ));
 
-                    if (args.projectStatus === 'ACTIVE_ONLY') {
+                    if (!args.includeArchived) {
                         statements.push(eb(
                             'dstk_user.projects.is_archived', 'is', false
-                        ));
-                    }
-
-                    if (args.projectStatus === 'ARCHIVED_ONLY') {
-                        statements.push(eb(
-                            'dstk_user.projects.is_archived', 'is', true
                         ));
                     }
 

--- a/apollo/src/graphql/user/projectQueries.ts
+++ b/apollo/src/graphql/user/projectQueries.ts
@@ -3,6 +3,8 @@ import { builder } from '../../builder.js';
 import { RegistryOperationError } from '../../utils/errors.js';
 import { userHasRole } from '../../utils/rls.js';
 import { db } from '../../db/kysely.js';
+import type { Expression, SqlBool } from 'kysely';
+import { Status } from '../misc/status.js';
 
 builder.queryFields((t) => ({
     listProjects: t.field({
@@ -11,6 +13,12 @@ builder.queryFields((t) => ({
             loggedIn: true,
         },
         args: {
+            projectName: t.arg.string(),
+            projectStatus: t.arg({
+                type: Status,
+                required: true,
+                defaultValue: 'ALL',
+            }),
             teamId: t.arg.string({ required: true }),
         },
         async resolve(_root, args, ctx) {
@@ -23,7 +31,33 @@ builder.queryFields((t) => ({
             const projects = await db
                 .selectFrom('dstk_user.projects')
                 .selectAll()
-                .where('dstk_user.projects.team_id', '=', args.teamId)
+                .where((eb) => {
+                    const statements: Expression<SqlBool>[] = [];
+
+                    statements.push(eb(
+                        'dstk_user.projects.team_id', '=', args.teamId,
+                    ));
+
+                    if (args.projectStatus === 'ACTIVE_ONLY') {
+                        statements.push(eb(
+                            'dstk_user.projects.is_archived', 'is', false
+                        ));
+                    }
+
+                    if (args.projectStatus === 'ARCHIVED_ONLY') {
+                        statements.push(eb(
+                            'dstk_user.projects.is_archived', 'is', true
+                        ));
+                    }
+
+                    if (args.projectName) {
+                        statements.push(eb(
+                            'dstk_user.projects.name', 'ilike', `%${args.projectName}%`,
+                        ))
+                    }
+
+                    return eb.and(statements)
+                })
                 .execute();
 
             return projects;


### PR DESCRIPTION
Adds the ability to search project by name. Also adds a `Status` enum that represents the "status" of different services (projects, storage providers, etc.) This enum was added because this is a common access pattern on the web, and I would imagine the CLI as well.

If there are strong objections, filtering on status could also be something strictly done from the client side since we aren't implementing any pagination on this resource,