### PR TITLE
Add Edit Project Mutation

### DIFF
--- a/apollo/src/graphql/user/projectMutations.ts
+++ b/apollo/src/graphql/user/projectMutations.ts
@@ -12,6 +12,14 @@ export const ProjectInputType = builder.inputType('ProjectInput', {
     }),
 });
 
+export const EditProjectInputType = builder.inputType('EditProjectInput', {
+    fields: (t) => ({
+        name: t.string({ required: true }),
+        description: t.string({ required: true }),
+        projectId: t.string({ required: true }),
+    }),
+});
+
 builder.mutationFields((t) => ({
     createProject: t.field({
         type: Project,
@@ -56,7 +64,6 @@ builder.mutationFields((t) => ({
         },
         async resolve(_root, args, ctx) {
             const results = await db.transaction().execute(async (trx) => {
-                // const project = await ObjectionProject.query().for(args.projectId).first();
                 const project = await trx
                     .selectFrom('dstk_user.projects')
                     .select(['dstk_user.projects.team_id', 'dstk_user.projects.is_archived'])
@@ -87,4 +94,47 @@ builder.mutationFields((t) => ({
             return results;
         },
     }),
+    editProject: t.field({
+        type: Project,
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            data: t.arg({ type: EditProjectInputType, required: true }),
+        },
+        async resolve(_root, args, ctx) {
+            const results = await db.transaction().execute(async (trx) => {
+                const project = await trx
+                    .selectFrom('dstk_user.projects')
+                    .select(['dstk_user.projects.team_id', 'dstk_user.projects.is_archived'])
+                    .where('dstk_user.projects.project_id', '=', args.data.projectId)
+                    .executeTakeFirstOrThrow(
+                        () => new RegistryOperationError({ name: 'PROJECT_PERMISSION_ERROR' }),
+                    );
+
+                await userHasRole({
+                    userId: ctx.user.user_id,
+                    teamId: project.team_id,
+                    roles: ['owner', 'member'],
+                });
+
+                if (project.is_archived) {
+                    new RegistryOperationError({ name: 'ARCHIVED_PROJECT_ERROR' });
+                }
+
+                const result = await trx
+                    .updateTable('dstk_user.projects')
+                    .set({
+                        description: args.data.description,
+                        name: args.data.name,
+                    })
+                    .where('dstk_user.projects.project_id', '=', args.data.projectId)
+                    .returningAll()
+                    .executeTakeFirstOrThrow();
+
+                return result;
+            });
+        return results;
+        }
+    })
 }));

--- a/apollo/src/graphql/user/projectMutations.ts
+++ b/apollo/src/graphql/user/projectMutations.ts
@@ -127,6 +127,8 @@ builder.mutationFields((t) => ({
                     .set({
                         description: args.data.description,
                         name: args.data.name,
+                        modified_by_id: ctx.user.user_id,
+                        date_modified: new Date(),
                     })
                     .where('dstk_user.projects.project_id', '=', args.data.projectId)
                     .returningAll()

--- a/apollo/src/utils/errors.ts
+++ b/apollo/src/utils/errors.ts
@@ -1,4 +1,5 @@
 type RegistryErrorName =
+    | 'ARCHIVED_PROJECT_ERROR'
     | 'ARCHIVED_STORAGE_ERROR'
     | 'PROVIDER_NOT_FOUND_ERROR'
     | 'ARCHIVED_MODEL_ERROR'
@@ -14,6 +15,7 @@ type RegistryErrorName =
     | 'VERSION_PERMISSION_ERROR';
 
 const RegistryErrorMessages = {
+    ARCHIVED_PROJECT_ERROR: 'Projects cannot be modified once archived',
     ARCHIVED_STORAGE_ERROR: 'New model versions cannot be added to an archived storage provider',
     PROVIDER_NOT_FOUND_ERROR:
         "Either this storage provider doesn't exist or you don't have permission to take that action",


### PR DESCRIPTION
Added a new Registry Error called `PROJECT_ARCHIVED_ERROR`. This error represents when a user attempts to edit a project that has been archived.

Added a mutation to allow users to edit a projects name and description. I explicitly left off the ability for the ability to change the associated team of the project because I didn't think that would be a normal use case, but we can add it in very easily if needed.