### PR TITLE
Add CRUD Operations for Projects

### DIFF
--- a/web/src/components/includeArchivedSwitch/IncludeArchivedSwitch.tsx
+++ b/web/src/components/includeArchivedSwitch/IncludeArchivedSwitch.tsx
@@ -1,0 +1,22 @@
+import { Switch } from '@mantine/core';
+import { useSearchParams } from 'react-router';
+
+export const IncludeArchivedSwitch = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const archived = searchParams.get('includeArchived') === 'true';
+
+  const handleArchiveSwitch = () => {
+    const next = new URLSearchParams(searchParams);
+    next.set('includeArchived', String(!archived));
+    setSearchParams(next, { replace: true });
+  };
+
+  return (
+    <Switch
+      checked={archived}
+      label='Include Archived'
+      labelPosition='left'
+      onChange={handleArchiveSwitch}
+    />
+  );
+};

--- a/web/src/components/modal/Modal.tsx
+++ b/web/src/components/modal/Modal.tsx
@@ -1,0 +1,30 @@
+import { Modal as ModalPrimitive } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
+
+type ModalProps = {
+  disabled?: boolean;
+} & Omit<
+  React.ComponentProps<typeof ModalPrimitive>,
+  'fullScreen' | 'transitionProps'
+>;
+
+export const Modal = ({ disabled = false, onClose, ...props }: ModalProps) => {
+  const isSmallScreen = useMediaQuery('(max-width: 768px)');
+
+  const handleClose = () => {
+    if (!disabled && onClose) {
+      onClose();
+    }
+  };
+
+  return (
+    <ModalPrimitive
+      fullScreen={isSmallScreen}
+      onClose={handleClose}
+      transitionProps={
+        isSmallScreen ? { duration: 200, transition: 'fade' } : {}
+      }
+      {...props}
+    />
+  );
+};

--- a/web/src/components/noResults/NoResults.tsx
+++ b/web/src/components/noResults/NoResults.tsx
@@ -1,0 +1,21 @@
+import { Center, Stack, Table, Text } from '@mantine/core';
+import { ChartNoAxesColumnIcon } from 'lucide-react';
+
+type NoResultsProps = {
+  colSpan: number;
+};
+
+export const NoResults = ({ colSpan }: NoResultsProps) => (
+  <Table.Tr>
+    <Table.Td colSpan={colSpan}>
+      <Center py={20}>
+        <Stack align='center' gap={2}>
+          <ChartNoAxesColumnIcon size={22} />
+          <Text c='dimmed' component='div' size='sm'>
+            No Results
+          </Text>
+        </Stack>
+      </Center>
+    </Table.Td>
+  </Table.Tr>
+);

--- a/web/src/components/searchParamInput/SearchParamInput.tsx
+++ b/web/src/components/searchParamInput/SearchParamInput.tsx
@@ -1,20 +1,18 @@
 import { TextInput } from '@mantine/core';
 import { SearchIcon } from 'lucide-react';
-import { SetURLSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 
 type SearchParamTextInput = {
   param: string;
   placeholder?: string;
-  searchParams: URLSearchParams;
-  setSearchParams: SetURLSearchParams;
 };
 
 export const SearchParamTextInput = ({
   param,
   placeholder = 'Search...',
-  searchParams,
-  setSearchParams,
 }: SearchParamTextInput) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
   return (
     <TextInput
       leftSection={<SearchIcon size={18} />}

--- a/web/src/components/searchParamInput/SearchParamInput.tsx
+++ b/web/src/components/searchParamInput/SearchParamInput.tsx
@@ -1,0 +1,30 @@
+import { TextInput } from '@mantine/core';
+import { SearchIcon } from 'lucide-react';
+import { SetURLSearchParams } from 'react-router';
+
+type SearchParamTextInput = {
+  param: string;
+  placeholder?: string;
+  searchParams: URLSearchParams;
+  setSearchParams: SetURLSearchParams;
+};
+
+export const SearchParamTextInput = ({
+  param,
+  placeholder = 'Search...',
+  searchParams,
+  setSearchParams,
+}: SearchParamTextInput) => {
+  return (
+    <TextInput
+      leftSection={<SearchIcon size={18} />}
+      onChange={(e) => {
+        const next = new URLSearchParams(searchParams);
+        next.set(param, e.target.value);
+        setSearchParams(next, { replace: true });
+      }}
+      placeholder={placeholder}
+      rightSectionWidth={42}
+    />
+  );
+};

--- a/web/src/config/paths.ts
+++ b/web/src/config/paths.ts
@@ -22,6 +22,10 @@ export const paths = {
       getPath: () => '/dashboard/overview',
       path: '/dashboard/overview',
     },
+    project: {
+      getPath: (projectId: string) => `/dashboard/projects/${projectId}`,
+      path: '/dashboard/projects/:projectId',
+    },
     projects: {
       getPath: () => '/dashboard/projects',
       path: '/dashboard/projects',

--- a/web/src/features/projects/loaders/projectsLoader.tsx
+++ b/web/src/features/projects/loaders/projectsLoader.tsx
@@ -1,0 +1,50 @@
+import { type LoaderFunctionArgs, redirect } from 'react-router';
+import { z } from 'zod/v4';
+
+import { gql } from '@/graphql';
+import { preloadQuery } from '@/lib/apollo';
+import { parseQueryParams } from '@/lib/parseQueryParams';
+import { useTeamStore } from '@/stores/teamStore';
+
+export const LIST_PROJECTS_FOR_TABLE = gql(`
+    query ListProjectsForTable(
+      $teamId: String!,
+      $includeArchived: Boolean!,
+      $projectName: String
+    ) {
+      listProjects(
+        teamId: $teamId,
+        includeArchived: $includeArchived,
+        projectName: $projectName
+      ) {
+        name
+        projectId
+        isArchived
+        description
+        dateModified
+      }
+    }
+`);
+
+const projectsLoaderSchema = z.object({
+  includeArchived: z.string().transform((val) => val === 'true'),
+  projectName: z.string().optional(),
+});
+
+export const projectsLoader = async ({ request }: LoaderFunctionArgs) => {
+  const { selectedTeam } = useTeamStore.getState();
+
+  const url = new URL(request.url);
+  if (!url.searchParams.has('includeArchived')) {
+    url.searchParams.set('includeArchived', 'false');
+    throw redirect(url.toString());
+  }
+
+  const { ...params } = parseQueryParams(request, projectsLoaderSchema);
+
+  return preloadQuery(LIST_PROJECTS_FOR_TABLE, {
+    variables: { teamId: selectedTeam!, ...params },
+  });
+};
+
+export type ProjectsLoader = Awaited<ReturnType<typeof projectsLoader>>;

--- a/web/src/lib/parseQueryParams.ts
+++ b/web/src/lib/parseQueryParams.ts
@@ -1,0 +1,10 @@
+import { ZodObject } from 'zod/v4';
+
+export const parseQueryParams = <T extends ZodObject>(
+  request: Request,
+  schema: T,
+) => {
+  const url = new URL(request.url);
+  const entries = Object.fromEntries(url.searchParams.entries());
+  return schema.parse(entries);
+};

--- a/web/src/pages/dashboard/projects/AddProject.tsx
+++ b/web/src/pages/dashboard/projects/AddProject.tsx
@@ -1,0 +1,108 @@
+import { useMutation } from '@apollo/client';
+import { Button, Flex, Stack, Textarea, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { zod4Resolver } from 'mantine-form-zod-resolver';
+import { z } from 'zod/v4';
+
+import type { CreateProjectMutationVariables } from '@/graphql/types';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+import { useTeamStore } from '@/stores/teamStore';
+
+const CREATE_PROJECT = gql(`
+  mutation CreateProject($data: ProjectInput!) {
+    createProject(data: $data) {
+      name
+    }
+  }
+`);
+
+const createProjectSchema = z.object({
+  description: z.string().min(1, 'Required'),
+  name: z.string().min(1, 'Required'),
+}) satisfies z.ZodType<Omit<CreateProjectMutationVariables['data'], 'teamId'>>;
+
+type CreateProjectSchema = z.infer<typeof createProjectSchema>;
+
+export const AddProject = () => {
+  const { selectedTeam } = useTeamStore();
+
+  const [createProject, { loading }] = useMutation(CREATE_PROJECT);
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const createProjectForm = useForm({
+    initialValues: {
+      description: '',
+      name: '',
+    },
+    mode: 'uncontrolled',
+    validate: zod4Resolver(createProjectSchema),
+  });
+
+  const onSubmit = (values: CreateProjectSchema) =>
+    createProject({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully created ${data.createProject?.name}`,
+          title: 'Success',
+        });
+        close();
+      },
+      refetchQueries: ['ListProjectsForTable', 'ListProjectsForSelect'],
+      variables: {
+        data: {
+          description: values.description,
+          name: values.name,
+          teamId: selectedTeam!,
+        },
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title='Add Project'
+      >
+        <form
+          onSubmit={createProjectForm.onSubmit((values) => onSubmit(values))}
+        >
+          <Stack gap='md'>
+            <TextInput
+              disabled={loading}
+              key={createProjectForm.key('name')}
+              label='Project Name'
+              withAsterisk
+              {...createProjectForm.getInputProps('name')}
+            />
+
+            <Textarea
+              disabled={loading}
+              key={createProjectForm.key('description')}
+              label='Description'
+              withAsterisk
+              {...createProjectForm.getInputProps('description')}
+            />
+          </Stack>
+
+          <Flex align='center' justify='end' mt='xl'>
+            <Button color='blue' loading={loading} radius='md' type='submit'>
+              Submit
+            </Button>
+          </Flex>
+        </form>
+      </Modal>
+
+      <Button fullWidth onClick={open}>
+        Add Project
+      </Button>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/projects/ArchiveProject.tsx
+++ b/web/src/pages/dashboard/projects/ArchiveProject.tsx
@@ -1,0 +1,109 @@
+import { useMutation } from '@apollo/client';
+import {
+  ActionIcon,
+  Button,
+  Stack,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { ArchiveIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+
+const ARCHIVE_PROJECT = gql(`
+  mutation ArchiveProject($projectId: String!) {
+    archiveProject(projectId: $projectId) {
+      name
+    }
+  }
+`);
+
+type ArchiveProjectProps = {
+  isArchived: boolean;
+  projectId: string;
+  projectName: string;
+};
+
+export const ArchiveProject = ({
+  isArchived,
+  projectId,
+  projectName,
+}: ArchiveProjectProps) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const [archiveProject, { loading }] = useMutation(ARCHIVE_PROJECT);
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const onSubmit = () =>
+    archiveProject({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully archived ${data.archiveProject?.name}`,
+          title: 'Success',
+        });
+        close();
+        setInputValue('');
+      },
+      refetchQueries: ['ListProjectsForTable', 'ListProjectsForSelect'],
+      variables: {
+        projectId,
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title={`Archive ${projectName}`}
+      >
+        <Stack gap='md'>
+          <Text size='sm'>
+            This action is{' '}
+            <Text c='red' fw={500} span>
+              irreversible
+            </Text>
+            . Archiving this project will permanently prevent any further
+            modifications or the addition of new models.
+          </Text>
+          <TextInput
+            label='Please type in the name of the project to continue'
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder={projectName}
+            value={inputValue}
+          />
+          <Button
+            color='red'
+            disabled={inputValue !== projectName || loading}
+            fullWidth
+            loading={loading}
+            mt='sm'
+            onClick={() => onSubmit()}
+            radius='md'
+          >
+            I understand, archive this project
+          </Button>
+        </Stack>
+      </Modal>
+
+      <Tooltip disabled={isArchived} label='Archive'>
+        <ActionIcon
+          color='red'
+          disabled={isArchived}
+          onClick={open}
+          variant='subtle'
+        >
+          <ArchiveIcon size={14} />
+        </ActionIcon>
+      </Tooltip>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/projects/EditProject.tsx
+++ b/web/src/pages/dashboard/projects/EditProject.tsx
@@ -1,0 +1,131 @@
+import { useMutation } from '@apollo/client';
+import {
+  ActionIcon,
+  Button,
+  Flex,
+  Stack,
+  Textarea,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { EditIcon } from 'lucide-react';
+import { zod4Resolver } from 'mantine-form-zod-resolver';
+import { z } from 'zod/v4';
+
+import type { EditProjectMutationVariables } from '@/graphql/types';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+
+const EDIT_PROJECT = gql(`
+  mutation EditProject($data: EditProjectInput!) {
+    editProject(data: $data) {
+        name
+    }
+  }
+`);
+
+const editProjectSchema = z.object({
+  description: z.string().min(1, 'Required'),
+  name: z.string().min(1, 'Required'),
+}) satisfies z.ZodType<Omit<EditProjectMutationVariables['data'], 'projectId'>>;
+
+type EditProjectProps = {
+  isArchived: boolean;
+  originalDescription: string;
+  originalName: string;
+  projectId: string;
+};
+
+type EditProjectSchema = z.infer<typeof editProjectSchema>;
+
+export const EditProject = ({
+  isArchived,
+  originalDescription,
+  originalName,
+  projectId,
+}: EditProjectProps) => {
+  const [createProject, { loading }] = useMutation(EDIT_PROJECT);
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const editProjectForm = useForm({
+    initialValues: {
+      description: originalDescription,
+      name: originalName,
+    },
+    mode: 'uncontrolled',
+    validate: zod4Resolver(editProjectSchema),
+  });
+
+  const onSubmit = (values: EditProjectSchema) =>
+    createProject({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully edited ${data.editProject?.name}`,
+          title: 'Success',
+        });
+        close();
+      },
+      refetchQueries: ['ListProjectsForTable', 'ListProjectsForSelect'],
+      variables: {
+        data: {
+          description: values.description,
+          name: values.name,
+          projectId,
+        },
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title={`Edit ${originalName}`}
+      >
+        <form onSubmit={editProjectForm.onSubmit((values) => onSubmit(values))}>
+          <Stack gap='md'>
+            <TextInput
+              disabled={loading}
+              key={editProjectForm.key('name')}
+              label='Project Name'
+              withAsterisk
+              {...editProjectForm.getInputProps('name')}
+            />
+
+            <Textarea
+              disabled={loading}
+              key={editProjectForm.key('description')}
+              label='Description'
+              withAsterisk
+              {...editProjectForm.getInputProps('description')}
+            />
+          </Stack>
+
+          <Flex align='center' justify='end' mt='xl'>
+            <Button color='blue' loading={loading} radius='md' type='submit'>
+              Submit
+            </Button>
+          </Flex>
+        </form>
+      </Modal>
+
+      <Tooltip disabled={isArchived} label='Edit'>
+        <ActionIcon
+          color='blue'
+          disabled={isArchived}
+          onClick={open}
+          variant='subtle'
+        >
+          <EditIcon size={14} />
+        </ActionIcon>
+      </Tooltip>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/projects/ProjectsPage.module.css
+++ b/web/src/pages/dashboard/projects/ProjectsPage.module.css
@@ -1,0 +1,45 @@
+.header {
+    @media (min-width: 768px) { 
+        display: flex; 
+        gap: 2rem; 
+        justify-content: space-between; 
+        align-items: center; 
+    }
+}
+
+.searchContainer {
+    width: 100%; 
+
+    @media (min-width: 768px) { 
+        width: 50%; 
+    }
+}
+
+.toolbar {
+    display: flex; 
+    gap: 1rem;
+    margin-top: 0.5rem; 
+    flex-direction: column-reverse; 
+    justify-content: flex-end; 
+    align-items: stretch; 
+    width: 100%;
+    margin-top: 0.5rem;
+
+    @media (min-width: 768px) {
+        gap: 0;
+        margin-left: 0.75rem;
+        margin-top: 0; 
+        flex-direction: row; 
+        align-items: center; 
+        width: auto; 
+    }
+}
+
+.buttonContainer {
+    margin-top: 0.5rem;
+
+    @media (min-width: 768px) { 
+        margin-top: 0;
+        margin-left: 0.75rem;
+    }
+}

--- a/web/src/pages/dashboard/projects/ProjectsPage.tsx
+++ b/web/src/pages/dashboard/projects/ProjectsPage.tsx
@@ -1,0 +1,39 @@
+import { Suspense } from 'react';
+import { useLoaderData, useSearchParams } from 'react-router';
+
+import type { ProjectsLoader } from '@/features/projects/loaders/projectsLoader';
+
+import { IncludeArchivedSwitch } from '@/components/includeArchivedSwitch/IncludeArchivedSwitch';
+import { SearchParamTextInput } from '@/components/searchParamInput/SearchParamInput';
+
+import { AddProject } from './AddProject';
+import styles from './ProjectsPage.module.css';
+import { ProjectsTable } from './ProjectsTable';
+
+export const ProjectsPage = () => {
+  const queryRef = useLoaderData() as ProjectsLoader;
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  return (
+    <>
+      <header className={styles.header}>
+        <div className={styles.searchContainer}>
+          <SearchParamTextInput
+            param='projectName'
+            searchParams={searchParams}
+            setSearchParams={setSearchParams}
+          />
+        </div>
+        <div className={styles.toolbar}>
+          <IncludeArchivedSwitch />
+          <div className={styles.buttonContainer}>
+            <AddProject />
+          </div>
+        </div>
+      </header>
+      <Suspense>
+        <ProjectsTable queryRef={queryRef} />
+      </Suspense>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/projects/ProjectsPage.tsx
+++ b/web/src/pages/dashboard/projects/ProjectsPage.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { useLoaderData, useSearchParams } from 'react-router';
+import { useLoaderData } from 'react-router';
 
 import type { ProjectsLoader } from '@/features/projects/loaders/projectsLoader';
 
@@ -12,17 +12,12 @@ import { ProjectsTable } from './ProjectsTable';
 
 export const ProjectsPage = () => {
   const queryRef = useLoaderData() as ProjectsLoader;
-  const [searchParams, setSearchParams] = useSearchParams();
 
   return (
     <>
       <header className={styles.header}>
         <div className={styles.searchContainer}>
-          <SearchParamTextInput
-            param='projectName'
-            searchParams={searchParams}
-            setSearchParams={setSearchParams}
-          />
+          <SearchParamTextInput param='projectName' />
         </div>
         <div className={styles.toolbar}>
           <IncludeArchivedSwitch />

--- a/web/src/pages/dashboard/projects/ProjectsTable.module.css
+++ b/web/src/pages/dashboard/projects/ProjectsTable.module.css
@@ -1,0 +1,11 @@
+.tableContainer {
+    margin-top: 2rem;
+}
+
+.tableRow {
+    white-space: nowrap;
+    
+    @mixin hover {
+        cursor: pointer;
+    }
+}

--- a/web/src/pages/dashboard/projects/ProjectsTable.tsx
+++ b/web/src/pages/dashboard/projects/ProjectsTable.tsx
@@ -1,0 +1,86 @@
+import { useReadQuery } from '@apollo/client';
+import { Badge, Card, Flex, Table } from '@mantine/core';
+import dayjs from 'dayjs';
+import { useNavigate } from 'react-router';
+
+import type { ProjectsLoader } from '@/features/projects/loaders/projectsLoader';
+
+import { NoResults } from '@/components/noResults/NoResults';
+import { paths } from '@/config/paths';
+
+import { ArchiveProject } from './ArchiveProject';
+import { EditProject } from './EditProject';
+import styles from './ProjectsTable.module.css';
+
+type ProjectsTableProps = {
+  queryRef: ProjectsLoader;
+};
+
+export const ProjectsTable = ({ queryRef }: ProjectsTableProps) => {
+  const { data } = useReadQuery(queryRef);
+
+  const navigate = useNavigate();
+
+  const rows =
+    data.listProjects?.map((project) => (
+      <Table.Tr
+        className={styles.tableRow}
+        key={project.projectId}
+        onClick={() =>
+          navigate(paths.dashboard.project.getPath(project.projectId ?? ''))
+        }
+      >
+        <Table.Td>{project.name}</Table.Td>
+        {/* TODO: Probably make this reusable */}
+        <Table.Td>
+          {project.description && project.description.length > 50
+            ? `${project.description.substring(0, 50)}...`
+            : project.description}
+        </Table.Td>
+        <Table.Td>
+          <Badge color={project.isArchived ? 'red' : 'blue'}>
+            {project.isArchived ? 'Archived' : 'Active'}
+          </Badge>
+        </Table.Td>
+        <Table.Td>{dayjs(project.dateModified).format('YYYY-MM-DD')}</Table.Td>
+        <Table.Td onClick={(e) => e.stopPropagation()}>
+          <Flex gap={2}>
+            <EditProject
+              isArchived={!!project.isArchived}
+              originalDescription={project.description ?? ''}
+              originalName={project.name ?? ''}
+              projectId={project.projectId ?? ''}
+            />
+            <ArchiveProject
+              isArchived={!!project.isArchived}
+              projectId={project.projectId ?? ''}
+              projectName={project.name ?? ''}
+            />
+          </Flex>
+        </Table.Td>
+      </Table.Tr>
+    )) ?? [];
+
+  return (
+    <div className={styles.tableContainer}>
+      <Card bg='transparent' p={0} withBorder>
+        <Table.ScrollContainer minWidth={500} type='native'>
+          <Table highlightOnHover>
+            <Table.Thead style={{ whiteSpace: 'nowrap' }}>
+              <Table.Tr>
+                <Table.Th>Name</Table.Th>
+                <Table.Th>Description</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Last Modified</Table.Th>
+                <Table.Th className='sr-only' />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.length > 0 ? rows : <NoResults colSpan={5} />}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      </Card>
+    </div>
+  );
+};

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -58,6 +58,26 @@ const createAppRouter = () =>
               },
               path: paths.dashboard.overview.path,
             },
+            {
+              handle: {
+                crumb: () => 'Projects',
+              },
+              lazy: async () => {
+                const { ProjectsPage } = await import(
+                  './pages/dashboard/projects/ProjectsPage'
+                );
+                return { Component: ProjectsPage };
+              },
+              loader: async (params) => {
+                const { projectsLoader } = await import(
+                  './features/projects/loaders/projectsLoader'
+                );
+
+                const queryRef = await projectsLoader(params);
+                return queryRef;
+              },
+              path: paths.dashboard.projects.path,
+            },
           ],
           id: 'dashboard',
           lazy: async () => {


### PR DESCRIPTION
Adds the ability to create, edit, update, and delete (archive) projects from the web client. The data is served through query preloaders that prevent the route transitioning until the initial request is complete. After that, all subsequent requests are hydrated through the url (which the different toggle and inputs control). This way, application states are easily shareable and debuggable, and we don't have to worry about the absolute hell of trying to get skeleton loaders to match up with the underlying UI.

Here are some of my famous screenshots:

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/cc9b0fc8-0d76-4d86-98ad-132c99812a43" />

<img width="694" alt="image" src="https://github.com/user-attachments/assets/32d801b8-0349-4e59-911e-61f996a9ab55" />

<img width="686" alt="image" src="https://github.com/user-attachments/assets/d6b24473-11e0-4767-8b08-7d39dc1a3971" />
