### PR TITLE
Add CRUD Operations for Storage Providers on the Frontend

### DIFF
--- a/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -5,6 +5,7 @@ import { StorageProviderObjectConnection } from '../storage-provider/storageProv
 import { RegistryOperationError } from '../../utils/errors.js';
 import { db } from '../../db/kysely.js';
 import { userHasRole } from '../../utils/rls.js';
+import type { Expression, SqlBool } from 'kysely';
 
 builder.queryFields((t) => ({
     listStorageProviders: t.field({
@@ -12,21 +13,42 @@ builder.queryFields((t) => ({
         authScopes: {
             loggedIn: true,
         },
-        async resolve(_root, _args, ctx) {
-            const userTeams = await db
-                .selectFrom('dstk_user.team_edges')
-                .select('dstk_user.team_edges.team_id')
-                .where('dstk_user.team_edges.user_id', '=', ctx.user.user_id)
-                .execute();
+        args: {
+            includeArchived: t.arg.boolean({ required: true, defaultValue: false }),
+            bucket: t.arg.string(),
+            teamId: t.arg.string({ required: true }),
+        },
+        async resolve(_root, args, ctx) {
+            await userHasRole({
+                userId: ctx.user.user_id,
+                teamId: args.teamId,
+                roles: ['owner', 'member', 'viewer'],
+            });
 
             const storageProviders = await db
                 .selectFrom('registry.storage_providers')
                 .selectAll()
-                .where(
-                    'registry.storage_providers.team_id',
-                    'in',
-                    userTeams.map((team) => team.team_id),
-                )
+                .where((eb) => {
+                    const statements: Expression<SqlBool>[] = [];
+
+                    statements.push(eb(
+                        'registry.storage_providers.team_id', '=', args.teamId,
+                    ));
+
+                    if (!args.includeArchived) {
+                        statements.push(eb(
+                            'registry.storage_providers.is_archived', 'is', false
+                        ));
+                    }
+
+                    if (args.bucket) {
+                        statements.push(eb(
+                            'registry.storage_providers.bucket', 'ilike', `%${args.bucket}%`,
+                        ))
+                    }
+
+                    return eb.and(statements)
+                })
                 .orderBy('registry.storage_providers.date_created')
                 .execute();
 

--- a/web/src/components/awsRegionSelect/AwsRegionSelect.tsx
+++ b/web/src/components/awsRegionSelect/AwsRegionSelect.tsx
@@ -1,0 +1,108 @@
+import {
+  Combobox,
+  Input,
+  InputBase,
+  InputBaseProps,
+  Text,
+  useCombobox,
+} from '@mantine/core';
+import { useState } from 'react';
+
+const AWS_REGIONS = [
+  { description: 'US East (N. Virginia)', value: 'us-east-1' },
+  { description: 'US East (Ohio)', value: 'us-east-2' },
+  { description: 'US West (N. California)', value: 'us-west-1' },
+  { description: 'US West (Oregon)', value: 'us-west-2' },
+  { description: 'Africa (Cape Town)', value: 'af-south-1' },
+  { description: 'Asia Pacific (Hong Kong)', value: 'ap-east-1' },
+  { description: 'Asia Pacific (Jakarta)', value: 'ap-southeast-3' },
+  { description: 'Asia Pacific (Mumbai)', value: 'ap-south-1' },
+  { description: 'Asia Pacific (Osaka)', value: 'ap-northeast-3' },
+  { description: 'Asia Pacific (Seoul)', value: 'ap-northeast-2' },
+  { description: 'Asia Pacific (Singapore)', value: 'ap-southeast-1' },
+  { description: 'Asia Pacific (Sydney)', value: 'ap-southeast-2' },
+  { description: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1' },
+  { description: 'Canada (Central)', value: 'ca-central-1' },
+  { description: 'Europe (Frankfurt)', value: 'eu-central-1' },
+  { description: 'Europe (Ireland)', value: 'eu-west-1' },
+  { description: 'Europe (London)', value: 'eu-west-2' },
+  { description: 'Europe (Milan)', value: 'eu-south-1' },
+  { description: 'Europe (Paris)', value: 'eu-west-3' },
+  { description: 'Europe (Stockholm)', value: 'eu-north-1' },
+  { description: 'Middle East (Bahrain)', value: 'me-south-1' },
+  { description: 'South America (São Paulo)', value: 'sa-east-1' },
+];
+
+const SelectOption = ({ description, value }: (typeof AWS_REGIONS)[number]) => (
+  <div>
+    <Text fw={500} fz='sm'>
+      {value}
+    </Text>
+    <Text fz='xs' opacity={0.6}>
+      {description}
+    </Text>
+  </div>
+);
+
+type AwsRegionSelectProps = {
+  disabled?: boolean;
+} & Omit<
+  InputBaseProps,
+  | 'component'
+  | 'label'
+  | 'multiline'
+  | 'onClick'
+  | 'pointer'
+  | 'rightSection'
+  | 'rightSectionPointerEvents'
+  | 'type'
+>;
+
+export const AwsRegionsSelect = ({
+  disabled,
+  ...props
+}: AwsRegionSelectProps) => {
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption(),
+  });
+
+  const [value, setValue] = useState<null | string>(null);
+  const selectedOption = AWS_REGIONS.find((region) => region.value === value);
+
+  const options = AWS_REGIONS.map((region) => (
+    <Combobox.Option key={region.value} value={region.value}>
+      <SelectOption {...region} />
+    </Combobox.Option>
+  ));
+
+  return (
+    <Combobox
+      disabled={disabled}
+      onOptionSubmit={(val) => {
+        setValue(val);
+        combobox.closeDropdown();
+      }}
+      store={combobox}
+    >
+      <Combobox.Target>
+        <InputBase
+          component='button'
+          label='Region'
+          multiline
+          onClick={() => combobox.toggleDropdown()}
+          pointer
+          rightSection={<Combobox.Chevron />}
+          rightSectionPointerEvents='none'
+          type='button'
+          {...props}
+        >
+          {selectedOption ? selectedOption.value : <Input.Placeholder />}
+        </InputBase>
+      </Combobox.Target>
+
+      <Combobox.Dropdown>
+        <Combobox.Options>{options}</Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+};

--- a/web/src/config/paths.ts
+++ b/web/src/config/paths.ts
@@ -38,6 +38,10 @@ export const paths = {
       getPath: () => '/dashboard/storage',
       path: '/dashboard/storage',
     },
+    storageItem: {
+      getPath: (providerId: string) => `/dashboard/storage/${providerId}`,
+      path: '/dashboard/storage/:providerId',
+    },
     teams: {
       getPath: () => '/dashboard/teams',
       path: '/dashboard/teams',

--- a/web/src/features/storage/loaders/storageProvidersLoader.tsx
+++ b/web/src/features/storage/loaders/storageProvidersLoader.tsx
@@ -1,0 +1,56 @@
+import { type LoaderFunctionArgs, redirect } from 'react-router';
+import { z } from 'zod/v4';
+
+import { gql } from '@/graphql';
+import { preloadQuery } from '@/lib/apollo';
+import { parseQueryParams } from '@/lib/parseQueryParams';
+import { useTeamStore } from '@/stores/teamStore';
+
+export const LIST_STORAGE_PROVIDERS_FOR_TABLE = gql(`
+  query ListStorageProvidersForTable(
+    $teamId: String!
+    $bucket: String
+    $includeArchived: Boolean!
+  ) {
+    listStorageProviders(
+      teamId: $teamId
+      bucket: $bucket
+      includeArchived: $includeArchived
+    ) {
+      accessKeyId
+      bucket
+      dateModified
+      endpointUrl
+      isArchived
+      providerId
+      region
+    }
+  }
+`);
+
+const storageProvidersLoaderSchema = z.object({
+  bucket: z.string().optional(),
+  includeArchived: z.string().transform((val) => val === 'true'),
+});
+
+export const storageProvidersLoader = async ({
+  request,
+}: LoaderFunctionArgs) => {
+  const { selectedTeam } = useTeamStore.getState();
+
+  const url = new URL(request.url);
+  if (!url.searchParams.has('includeArchived')) {
+    url.searchParams.set('includeArchived', 'false');
+    throw redirect(url.toString());
+  }
+
+  const { ...params } = parseQueryParams(request, storageProvidersLoaderSchema);
+
+  return preloadQuery(LIST_STORAGE_PROVIDERS_FOR_TABLE, {
+    variables: { teamId: selectedTeam!, ...params },
+  });
+};
+
+export type StorageProvidersLoader = Awaited<
+  ReturnType<typeof storageProvidersLoader>
+>;

--- a/web/src/pages/dashboard/storage/AddStorageProvider.tsx
+++ b/web/src/pages/dashboard/storage/AddStorageProvider.tsx
@@ -1,0 +1,161 @@
+import { useMutation } from '@apollo/client';
+import {
+  Button,
+  Flex,
+  Group,
+  PasswordInput,
+  Stack,
+  TextInput,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { zod4Resolver } from 'mantine-form-zod-resolver';
+import { z } from 'zod/v4';
+
+import type { CreateStorageProviderMutationVariables } from '@/graphql/types';
+
+import { AwsRegionsSelect } from '@/components/awsRegionSelect/AwsRegionSelect';
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+import { useTeamStore } from '@/stores/teamStore';
+
+const CREATE_STORAGE_PROVIDER = gql(`
+  mutation CreateStorageProvider($data: StorageProviderInput!) {
+    createStorageProvider(data: $data) {
+        bucket
+    }
+}`);
+
+const createStorageProviderSchema = z.object({
+  accessKeyId: z.string().min(1, 'Required'),
+  bucket: z.string().min(1, 'Required'),
+  endpointUrl: z.string().min(1, 'Required'),
+  //   TODO: Enum with literals
+  region: z.string().min(1, 'Required'),
+  secretAccessKey: z.string().min(1, 'Required'),
+}) satisfies z.ZodType<
+  Omit<CreateStorageProviderMutationVariables['data'], 'teamId'>
+>;
+
+type CreateStorageProviderSchema = z.infer<typeof createStorageProviderSchema>;
+
+export const AddStorageProvider = () => {
+  const { selectedTeam } = useTeamStore();
+
+  const [createStorageProvider, { loading }] = useMutation(
+    CREATE_STORAGE_PROVIDER,
+  );
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const createStorageProviderForm = useForm({
+    initialValues: {
+      accessKeyId: '',
+      bucket: '',
+      endpointUrl: '',
+      region: '',
+      secretAccessKey: '',
+    },
+    mode: 'uncontrolled',
+    validate: zod4Resolver(createStorageProviderSchema),
+  });
+
+  const onSubmit = (values: CreateStorageProviderSchema) =>
+    createStorageProvider({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully added ${data.createStorageProvider?.bucket}`,
+          title: 'Success',
+        });
+        close();
+      },
+      refetchQueries: [
+        'ListStorageProvidersForTable',
+        'ListStorageProvidersForSelect',
+      ],
+      variables: {
+        data: {
+          accessKeyId: values.accessKeyId,
+          bucket: values.bucket,
+          endpointUrl: values.endpointUrl,
+          region: values.region,
+          secretAccessKey: values.secretAccessKey,
+          teamId: selectedTeam!,
+        },
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title='Add Storage Provider'
+      >
+        <form
+          onSubmit={createStorageProviderForm.onSubmit((values) =>
+            onSubmit(values),
+          )}
+        >
+          <Stack gap='md'>
+            <TextInput
+              disabled={loading}
+              key={createStorageProviderForm.key('bucket')}
+              label='Bucket Name'
+              withAsterisk
+              {...createStorageProviderForm.getInputProps('bucket')}
+            />
+
+            {/* TODO: Stack on sm */}
+            <Group grow>
+              <AwsRegionsSelect
+                disabled={loading}
+                key={createStorageProviderForm.key('region')}
+                withAsterisk
+                {...createStorageProviderForm.getInputProps('region')}
+              />
+              <TextInput
+                disabled={loading}
+                key={createStorageProviderForm.key('endpointUrl')}
+                label='Endpoint URL'
+                withAsterisk
+                {...createStorageProviderForm.getInputProps('endpointUrl')}
+              />
+            </Group>
+
+            {/* TODO: Stack on sm */}
+            <Group grow>
+              <PasswordInput
+                disabled={loading}
+                key={createStorageProviderForm.key('accessKeyId')}
+                label='Access Key'
+                withAsterisk
+                {...createStorageProviderForm.getInputProps('accessKeyId')}
+              />
+              <PasswordInput
+                disabled={loading}
+                key={createStorageProviderForm.key('secretAccessKey')}
+                label='Secret Access Key'
+                withAsterisk
+                {...createStorageProviderForm.getInputProps('secretAccessKey')}
+              />
+            </Group>
+          </Stack>
+
+          <Flex align='center' justify='end' mt='xl'>
+            <Button color='blue' loading={loading} radius='md' type='submit'>
+              Submit
+            </Button>
+          </Flex>
+        </form>
+      </Modal>
+
+      <Button fullWidth onClick={open}>
+        Add Storage Provider
+      </Button>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/storage/ArchiveStorageProvider.tsx
+++ b/web/src/pages/dashboard/storage/ArchiveStorageProvider.tsx
@@ -1,0 +1,114 @@
+import { useMutation } from '@apollo/client';
+import {
+  ActionIcon,
+  Button,
+  Stack,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { ArchiveIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+
+const ARCHIVE_STORAGE_PROVIDER = gql(`
+  mutation ArchiveStorageProvider($providerId: String!) {
+    archiveStorageProvider(providerId: $providerId) {
+      bucket
+    }
+  }
+`);
+
+type ArchiveStorageProvider = {
+  bucket: string;
+  isArchived: boolean;
+  providerId: string;
+};
+
+export const ArchiveStorageProvider = ({
+  bucket,
+  isArchived,
+  providerId,
+}: ArchiveStorageProvider) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const [archiveStorageProvider, { loading }] = useMutation(
+    ARCHIVE_STORAGE_PROVIDER,
+  );
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const onSubmit = () =>
+    archiveStorageProvider({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully archived ${data.archiveStorageProvider?.bucket}`,
+          title: 'Success',
+        });
+        close();
+        setInputValue('');
+      },
+      refetchQueries: [
+        'ListStorageProvidersForTable',
+        'ListStorageProvidersForSelect',
+      ],
+      variables: {
+        providerId,
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title={`Archive ${bucket}`}
+      >
+        <Stack gap='md'>
+          <Text size='sm'>
+            This action is{' '}
+            <Text c='red' fw={500} span>
+              irreversible
+            </Text>
+            . Archiving this bucket will permanently prevent any further
+            addition of resources.
+          </Text>
+          <TextInput
+            label='Please type in the name of the bucket to continue'
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder={bucket}
+            value={inputValue}
+          />
+          <Button
+            color='red'
+            disabled={inputValue !== bucket || loading}
+            fullWidth
+            loading={loading}
+            mt='sm'
+            onClick={() => onSubmit()}
+            radius='md'
+          >
+            I understand, archive this bucket
+          </Button>
+        </Stack>
+      </Modal>
+
+      <Tooltip disabled={isArchived} label='Archive'>
+        <ActionIcon
+          color='red'
+          disabled={isArchived}
+          onClick={open}
+          variant='subtle'
+        >
+          <ArchiveIcon size={14} />
+        </ActionIcon>
+      </Tooltip>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/storage/EditStorageProvider.tsx
+++ b/web/src/pages/dashboard/storage/EditStorageProvider.tsx
@@ -1,0 +1,135 @@
+import { useMutation } from '@apollo/client';
+import {
+  ActionIcon,
+  Button,
+  Flex,
+  PasswordInput,
+  Stack,
+  Tooltip,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { EditIcon } from 'lucide-react';
+import { zod4Resolver } from 'mantine-form-zod-resolver';
+import { z } from 'zod/v4';
+
+import type { EditStorageProviderMutationVariables } from '@/graphql/types';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+
+const EDIT_STORAGE_PROVIDER = gql(`
+  mutation EditStorageProvider($data: EditStorageProviderInput!) {
+    editStorageProvider(data: $data) {
+        bucket
+    }
+  }
+`);
+
+const editStorageProviderSchema = z.object({
+  accessKeyId: z.string().min(1, 'Required'),
+  secretAccessKey: z.string().min(1, 'Required'),
+}) satisfies z.ZodType<
+  Omit<EditStorageProviderMutationVariables['data'], 'providerId'>
+>;
+
+type EditStorageProviderProps = {
+  bucket: string;
+  isArchived: boolean;
+  originalAccessKeyId: string;
+  providerId: string;
+};
+
+type EditStorageProviderSchema = z.infer<typeof editStorageProviderSchema>;
+
+export const EditStorageProvider = ({
+  bucket,
+  isArchived,
+  originalAccessKeyId,
+  providerId,
+}: EditStorageProviderProps) => {
+  const [editStorageProvider, { loading }] = useMutation(EDIT_STORAGE_PROVIDER);
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const editProjectForm = useForm({
+    initialValues: {
+      accessKeyId: originalAccessKeyId,
+      secretAccessKey: '',
+    },
+    mode: 'uncontrolled',
+    validate: zod4Resolver(editStorageProviderSchema),
+  });
+
+  const onSubmit = (values: EditStorageProviderSchema) =>
+    editStorageProvider({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully edited ${data.editStorageProvider?.bucket}`,
+          title: 'Success',
+        });
+        close();
+      },
+      refetchQueries: [
+        'ListStorageProvidersForTable',
+        'ListStorageProvidersForSelect',
+      ],
+      variables: {
+        data: {
+          accessKeyId: values.accessKeyId,
+          providerId,
+          secretAccessKey: values.secretAccessKey,
+        },
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title={`Edit ${bucket}`}
+      >
+        <form onSubmit={editProjectForm.onSubmit((values) => onSubmit(values))}>
+          <Stack gap='md'>
+            <PasswordInput
+              disabled={loading}
+              key={editProjectForm.key('accessKeyId')}
+              label='Access Key'
+              withAsterisk
+              {...editProjectForm.getInputProps('accessKeyId')}
+            />
+
+            <PasswordInput
+              disabled={loading}
+              key={editProjectForm.key('secretAccessKey')}
+              label='Secret Access Key'
+              withAsterisk
+              {...editProjectForm.getInputProps('secretAccessKey')}
+            />
+          </Stack>
+
+          <Flex align='center' justify='end' mt='xl'>
+            <Button color='blue' loading={loading} radius='md' type='submit'>
+              Submit
+            </Button>
+          </Flex>
+        </form>
+      </Modal>
+
+      <Tooltip disabled={isArchived} label='Edit'>
+        <ActionIcon
+          color='blue'
+          disabled={isArchived}
+          onClick={open}
+          variant='subtle'
+        >
+          <EditIcon size={14} />
+        </ActionIcon>
+      </Tooltip>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/storage/StorageProvidersPage.module.css
+++ b/web/src/pages/dashboard/storage/StorageProvidersPage.module.css
@@ -1,0 +1,45 @@
+.header {
+    @media (min-width: 768px) { 
+        display: flex; 
+        gap: 2rem; 
+        justify-content: space-between; 
+        align-items: center; 
+    }
+}
+
+.searchContainer {
+    width: 100%; 
+
+    @media (min-width: 768px) { 
+        width: 50%; 
+    }
+}
+
+.toolbar {
+    display: flex; 
+    gap: 1rem;
+    margin-top: 0.5rem; 
+    flex-direction: column-reverse; 
+    justify-content: flex-end; 
+    align-items: stretch; 
+    width: 100%;
+    margin-top: 0.5rem;
+
+    @media (min-width: 768px) {
+        gap: 0;
+        margin-left: 0.75rem;
+        margin-top: 0; 
+        flex-direction: row; 
+        align-items: center; 
+        width: auto; 
+    }
+}
+
+.buttonContainer {
+    margin-top: 0.5rem;
+
+    @media (min-width: 768px) { 
+        margin-top: 0;
+        margin-left: 0.75rem;
+    }
+}

--- a/web/src/pages/dashboard/storage/StorageProvidersPage.tsx
+++ b/web/src/pages/dashboard/storage/StorageProvidersPage.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react';
+import { useLoaderData } from 'react-router';
+
+import type { StorageProvidersLoader } from '@/features/storage/loaders/storageProvidersLoader';
+
+import { IncludeArchivedSwitch } from '@/components/includeArchivedSwitch/IncludeArchivedSwitch';
+import { SearchParamTextInput } from '@/components/searchParamInput/SearchParamInput';
+
+import { AddStorageProvider } from './AddStorageProvider';
+import styles from './StorageProvidersPage.module.css';
+import { StorageProvidersTable } from './StorageProvidersTable';
+
+export const StorageProvidersPage = () => {
+  const queryRef = useLoaderData() as StorageProvidersLoader;
+
+  return (
+    <>
+      <header className={styles.header}>
+        <div className={styles.searchContainer}>
+          <SearchParamTextInput param='bucket' />
+        </div>
+        <div className={styles.toolbar}>
+          <IncludeArchivedSwitch />
+          <div className={styles.buttonContainer}>
+            <AddStorageProvider />
+          </div>
+        </div>
+      </header>
+      <Suspense>
+        <StorageProvidersTable queryRef={queryRef} />
+      </Suspense>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/storage/StorageProvidersTable.module.css
+++ b/web/src/pages/dashboard/storage/StorageProvidersTable.module.css
@@ -1,0 +1,11 @@
+.tableContainer {
+    margin-top: 2rem;
+}
+
+.tableRow {
+    white-space: nowrap;
+    
+    @mixin hover {
+        cursor: pointer;
+    }
+}

--- a/web/src/pages/dashboard/storage/StorageProvidersTable.tsx
+++ b/web/src/pages/dashboard/storage/StorageProvidersTable.tsx
@@ -1,0 +1,90 @@
+import { useReadQuery } from '@apollo/client';
+import { Badge, Card, Flex, Table } from '@mantine/core';
+import dayjs from 'dayjs';
+import { useNavigate } from 'react-router';
+
+import type { StorageProvidersLoader } from '@/features/storage/loaders/storageProvidersLoader';
+
+import { NoResults } from '@/components/noResults/NoResults';
+import { paths } from '@/config/paths';
+
+import { ArchiveStorageProvider } from './ArchiveStorageProvider';
+import { EditStorageProvider } from './EditStorageProvider';
+import styles from './StorageProvidersTable.module.css';
+
+type StorageProvidersTableProps = {
+  queryRef: StorageProvidersLoader;
+};
+
+export const StorageProvidersTable = ({
+  queryRef,
+}: StorageProvidersTableProps) => {
+  const { data } = useReadQuery(queryRef);
+
+  const navigate = useNavigate();
+
+  const rows =
+    data.listStorageProviders?.map((storageProvider) => (
+      <Table.Tr
+        className={styles.tableRow}
+        key={storageProvider.providerId}
+        onClick={() =>
+          navigate(
+            paths.dashboard.storageItem.getPath(
+              storageProvider.providerId ?? '',
+            ),
+          )
+        }
+      >
+        <Table.Td>{storageProvider.bucket}</Table.Td>
+        <Table.Td>{storageProvider.region}</Table.Td>
+        <Table.Td>{storageProvider.endpointUrl}</Table.Td>
+        <Table.Td>
+          <Badge color={storageProvider.isArchived ? 'red' : 'blue'}>
+            {storageProvider.isArchived ? 'Archived' : 'Active'}
+          </Badge>
+        </Table.Td>
+        <Table.Td>
+          {dayjs(storageProvider.dateModified).format('YYYY-MM-DD')}
+        </Table.Td>
+        <Table.Td onClick={(e) => e.stopPropagation()}>
+          <Flex gap={2}>
+            <EditStorageProvider
+              bucket={storageProvider.bucket ?? ''}
+              isArchived={!!storageProvider.isArchived}
+              originalAccessKeyId={storageProvider.accessKeyId ?? ''}
+              providerId={storageProvider.providerId ?? ''}
+            />
+            <ArchiveStorageProvider
+              bucket={storageProvider.bucket ?? ''}
+              isArchived={!!storageProvider.isArchived}
+              providerId={storageProvider.providerId ?? ''}
+            />
+          </Flex>
+        </Table.Td>
+      </Table.Tr>
+    )) ?? [];
+
+  return (
+    <div className={styles.tableContainer}>
+      <Card bg='transparent' p={0} withBorder>
+        <Table.ScrollContainer minWidth={500} type='native'>
+          <Table highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Bucket Name</Table.Th>
+                <Table.Th>Region</Table.Th>
+                <Table.Th>Endpoint</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Last Modified</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.length > 0 ? rows : <NoResults colSpan={5} />}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      </Card>
+    </div>
+  );
+};

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -78,6 +78,26 @@ const createAppRouter = () =>
               },
               path: paths.dashboard.projects.path,
             },
+            {
+              handle: {
+                crumb: () => 'Storage',
+              },
+              lazy: async () => {
+                const { StorageProvidersPage } = await import(
+                  './pages/dashboard/storage/StorageProvidersPage'
+                );
+                return { Component: StorageProvidersPage };
+              },
+              loader: async (params) => {
+                const { storageProvidersLoader } = await import(
+                  './features/storage/loaders/storageProvidersLoader'
+                );
+
+                const queryRef = await storageProvidersLoader(params);
+                return queryRef;
+              },
+              path: paths.dashboard.storage.path,
+            },
           ],
           id: 'dashboard',
           lazy: async () => {


### PR DESCRIPTION
Altered the `listStorageProviders` query to include the following arguments:
  - bucket name
  - archived indicator
  - and team id

On the frontend, users now have the ability to perform all crud operations. The layout of these components is identical to that of the projects page.

Here is an example of the add storage provider component:

![image](https://github.com/user-attachments/assets/c9ddb003-f6f0-422f-af82-9749fd284ace)
