### PR TITLE
Add CRUD Features for Teams

### DIFF
--- a/apollo/src/graphql/user/team.ts
+++ b/apollo/src/graphql/user/team.ts
@@ -26,6 +26,8 @@ builder.objectType(Team, {
                 return root.date_modified.toISOString();
             },
         }),
+        description: t.exposeString('description'),
+        isArchived: t.exposeBoolean('is_archived'),
         name: t.exposeString('name'),
     }),
 });

--- a/apollo/src/graphql/user/teamMutations.ts
+++ b/apollo/src/graphql/user/teamMutations.ts
@@ -27,6 +27,14 @@ export const AddTeamMemberInputType = builder.inputType('AddTeamMemberInput', {
     }),
 });
 
+export const EditTeamInputType = builder.inputType('EditTeamInput', {
+    fields: (t) => ({
+        name: t.string({ required: true }),
+        description: t.string({ required: true }),
+        teamId: t.string({ required: true }),
+    }),
+});
+
 builder.mutationFields((t) => ({
     createTeam: t.field({
         type: Team,
@@ -45,6 +53,92 @@ builder.mutationFields((t) => ({
 
             return team;
         },
+    }),
+    archiveTeam: t.field({
+        type: Team,
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            teamId: t.arg.string({ required: true }),
+        },
+        async resolve(_root, args, ctx) {
+            const results = await db.transaction().execute(async (trx) => {
+                await userHasRole({
+                    userId: ctx.user.user_id,
+                    teamId: args.teamId,
+                    roles: ['owner'],
+                });
+
+                const team = await trx
+                    .selectFrom('dstk_user.teams')
+                    .select(['dstk_user.teams.is_archived'])
+                    .where('dstk_user.teams.team_id', '=', args.teamId)
+                    .executeTakeFirstOrThrow(
+                        () => new RegistryOperationError({ name: 'TEAM_PERMISSION_ERROR' }),
+                    );
+
+                const result = await trx
+                    .updateTable('dstk_user.teams')
+                    .set({
+                        modified_by_id: ctx.user.user_id,
+                        date_modified: new Date(),
+                        is_archived: !team.is_archived,
+                    })
+                    .where('dstk_user.teams.team_id', '=', args.teamId)
+                    .returningAll()
+                    .executeTakeFirstOrThrow();
+
+                return result;
+            });
+            return results;
+        },
+    }),
+    editTeam: t.field({
+        type: Team,
+        authScopes: {
+            loggedIn: true,
+        },
+        args: {
+            data: t.arg({ type: EditTeamInputType, required: true }),
+        },
+        async resolve(_root, args, ctx) {
+            const results = await db.transaction().execute(async (trx) => {
+                await userHasRole({
+                    userId: ctx.user.user_id,
+                    teamId: args.data.teamId,
+                    roles: ['owner'],
+                });
+
+                const team = await trx
+                    .selectFrom('dstk_user.teams')
+                    .select(['dstk_user.teams.team_id', 'dstk_user.teams.is_archived'])
+                    .where('dstk_user.teams.team_id', '=', args.data.teamId)
+                    .executeTakeFirstOrThrow(
+                        () => new RegistryOperationError({ name: 'TEAM_PERMISSION_ERROR' }),
+                    );
+
+                if (team.is_archived) {
+                    new RegistryOperationError({ name: 'ARCHIVED_TEAM_ERROR' });
+                }
+
+                const result = await trx
+                    .updateTable('dstk_user.teams')
+                    .set({
+                        description: args.data.description,
+                        name: args.data.name,
+                        modified_by_id: ctx.user.user_id,
+                        date_modified: new Date(),
+                    })
+                    .where('dstk_user.teams.team_id', '=', args.data.teamId)
+                    .returningAll()
+                    .executeTakeFirstOrThrow();
+
+                return result;
+            });
+
+            return results;
+        }
     }),
     addToTeam: t.boolean({
         authScopes: {

--- a/apollo/src/graphql/user/teamQueries.ts
+++ b/apollo/src/graphql/user/teamQueries.ts
@@ -12,6 +12,8 @@ builder.queryFields((t) => ({
             loggedIn: true,
         },
         args: {
+            includeArchived: t.arg.boolean({ required: true, defaultValue: false }),
+            teamName: t.arg.string(),
             teamId: t.arg.string(),
         },
         async resolve(_root, args, ctx) {
@@ -38,11 +40,27 @@ builder.queryFields((t) => ({
             const userTeams = await db
                 .selectFrom('dstk_user.teams')
                 .selectAll()
-                .where(
-                    'dstk_user.teams.team_id',
-                    'in',
-                    userTeamEdges.map((edge) => edge.team_id),
-                )
+                .where((eb) => {
+                    const statements: Expression<SqlBool>[] = [];
+
+                    statements.push(eb(
+                        'dstk_user.teams.team_id', 'in', userTeamEdges.map((edge) => edge.team_id)
+                    ));
+
+                    if (!args.includeArchived) {
+                        statements.push(eb(
+                            'dstk_user.teams.is_archived', 'is', false
+                        ));
+                    }
+
+                    if (args.teamName) {
+                        statements.push(eb(
+                            'dstk_user.teams.name', 'ilike', `%${args.teamName}%`,
+                        ))
+                    }
+
+                    return eb.and(statements)
+                })
                 .execute();
 
             return userTeams;

--- a/apollo/src/utils/errors.ts
+++ b/apollo/src/utils/errors.ts
@@ -1,6 +1,7 @@
 type RegistryErrorName =
     | 'ARCHIVED_PROJECT_ERROR'
     | 'ARCHIVED_STORAGE_ERROR'
+    | 'ARCHIVED_TEAM_ERROR'
     | 'PROVIDER_NOT_FOUND_ERROR'
     | 'ARCHIVED_MODEL_ERROR'
     | 'ARCHIVED_MODEL_VERSION_ERROR'
@@ -17,6 +18,7 @@ type RegistryErrorName =
 const RegistryErrorMessages = {
     ARCHIVED_PROJECT_ERROR: 'Projects cannot be modified once archived',
     ARCHIVED_STORAGE_ERROR: 'New model versions cannot be added to an archived storage provider',
+    ARCHIVED_TEAM_ERROR: 'Teams cannot be modifed once archived',
     PROVIDER_NOT_FOUND_ERROR:
         "Either this storage provider doesn't exist or you don't have permission to take that action",
     ARCHIVED_MODEL_ERROR: 'New model versions cannot be added to archived models',

--- a/web/src/config/paths.ts
+++ b/web/src/config/paths.ts
@@ -46,6 +46,10 @@ export const paths = {
       getPath: (providerId: string) => `/dashboard/storage/${providerId}`,
       path: '/dashboard/storage/:providerId',
     },
+    team: {
+      getPath: (teamId: string) => `/dashboard/teams/${teamId}`,
+      path: '/dashboard/teams/:teamId',
+    },
     teams: {
       getPath: () => '/dashboard/teams',
       path: '/dashboard/teams',

--- a/web/src/features/teams/loaders/teamsLoader.ts
+++ b/web/src/features/teams/loaders/teamsLoader.ts
@@ -1,12 +1,55 @@
+import type { LoaderFunctionArgs } from 'react-router';
+
+import { z } from 'zod/v4';
+
 import { gql } from '@/graphql';
 import { preloadQuery } from '@/lib/apollo';
+import { ensureDefaultQueryParams } from '@/lib/ensureDefaultQueryParams';
+import { parseQueryParams } from '@/lib/parseQueryParams';
 
-export const LIST_TEAMS = gql(`
-    query ListTeams {
-        listTeams {
-            name
-            teamId
-        }
-    }`);
+export const LIST_TEAMS_FOR_DROPDOWN = gql(`
+  query ListTeamsForDropdown {
+    listTeams {
+      name
+      teamId
+    }
+  }
+`);
 
-export const teamsLoader = async () => preloadQuery(LIST_TEAMS).toPromise();
+export const teamsDropdownLoader = async () =>
+  preloadQuery(LIST_TEAMS_FOR_DROPDOWN).toPromise();
+
+export type TeamsDropdownLoader = Awaited<
+  ReturnType<typeof teamsDropdownLoader>
+>;
+
+export const LIST_TEAMS_FOR_TABLE = gql(`
+  query ListTeamsForTable($includeArchived: Boolean!, $teamName: String) {
+    listTeams(includeArchived: $includeArchived, teamName: $teamName) {
+      dateModified
+      description
+      isArchived
+      name
+      teamId
+    }
+  }
+`);
+
+const teamsTableSchema = z.object({
+  includeArchived: z.string().transform((val) => val === 'true'),
+  teamName: z.string().optional(),
+});
+
+export const teamsTableLoader = async ({ request }: LoaderFunctionArgs) => {
+  ensureDefaultQueryParams(request, {
+    includeArchived: 'false',
+  });
+
+  const { ...params } = parseQueryParams(request, teamsTableSchema);
+
+  return preloadQuery(LIST_TEAMS_FOR_TABLE, {
+    variables: { ...params },
+  }).toPromise();
+};
+
+export type TeamsTableLoader = Awaited<ReturnType<typeof teamsTableLoader>>;

--- a/web/src/layouts/dashboard/TeamSelect.tsx
+++ b/web/src/layouts/dashboard/TeamSelect.tsx
@@ -1,16 +1,14 @@
-import { PreloadedQueryRef, useReadQuery } from '@apollo/client';
+import { useReadQuery } from '@apollo/client';
 import { Select } from '@mantine/core';
 import { useEffect } from 'react';
 import { useRouteLoaderData } from 'react-router';
 
-import { ListTeamsQuery } from '@/graphql/graphql';
+import type { TeamsDropdownLoader } from '@/features/teams/loaders/teamsLoader';
+
 import { useTeamStore } from '@/stores/teamStore';
 
 export const TeamSelect = () => {
-  const queryRef = useRouteLoaderData('dashboard') as PreloadedQueryRef<
-    ListTeamsQuery,
-    undefined
-  >;
+  const queryRef = useRouteLoaderData('dashboard') as TeamsDropdownLoader;
   const { data } = useReadQuery(queryRef);
 
   const { selectedTeam, setSelectedTeam } = useTeamStore();

--- a/web/src/pages/dashboard/teams/AddTeam.tsx
+++ b/web/src/pages/dashboard/teams/AddTeam.tsx
@@ -1,0 +1,109 @@
+import { useMutation } from '@apollo/client';
+import { Button, Flex, Stack, Textarea, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { zod4Resolver } from 'mantine-form-zod-resolver';
+import { z } from 'zod/v4';
+
+import type { CreateTeamMutationVariables } from '@/graphql/types';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+import { useTeamStore } from '@/stores/teamStore';
+
+const CREATE_TEAM = gql(`
+  mutation CreateTeam($data: TeamInput!) {
+    createTeam(data: $data) {
+      name
+      teamId
+    }
+  }
+`);
+
+const createTeamSchema = z.object({
+  description: z.string().min(1, 'Required'),
+  name: z.string().min(1, 'Required'),
+}) satisfies z.ZodType<CreateTeamMutationVariables['data']>;
+
+type CreateTeamSchema = z.infer<typeof createTeamSchema>;
+
+export const AddTeam = () => {
+  const { setSelectedTeam } = useTeamStore();
+
+  const [createTeam, { loading }] = useMutation(CREATE_TEAM);
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const createTeamForm = useForm({
+    initialValues: {
+      description: '',
+      name: '',
+    },
+    mode: 'uncontrolled',
+    validate: zod4Resolver(createTeamSchema),
+  });
+
+  const onSubmit = (values: CreateTeamSchema) =>
+    createTeam({
+      onCompleted: (data) => {
+        if (data.createTeam?.teamId) {
+          setSelectedTeam(data.createTeam?.teamId);
+        }
+        notifications.show({
+          message: `Successfully created ${data.createTeam?.name}`,
+          title: 'Success',
+        });
+        close();
+      },
+      refetchQueries: ['ListTeamsForDropdown', 'ListTeamsForTable'],
+      variables: {
+        data: {
+          description: values.description,
+          name: values.name,
+        },
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title='Add Team'
+      >
+        <form onSubmit={createTeamForm.onSubmit((values) => onSubmit(values))}>
+          <Stack gap='md'>
+            <TextInput
+              disabled={loading}
+              key={createTeamForm.key('name')}
+              label='Team Name'
+              withAsterisk
+              {...createTeamForm.getInputProps('name')}
+            />
+
+            <Textarea
+              disabled={loading}
+              key={createTeamForm.key('description')}
+              label='Description'
+              withAsterisk
+              {...createTeamForm.getInputProps('description')}
+            />
+          </Stack>
+
+          <Flex align='center' justify='end' mt='xl'>
+            <Button color='blue' loading={loading} radius='md' type='submit'>
+              Submit
+            </Button>
+          </Flex>
+        </form>
+      </Modal>
+
+      <Button fullWidth onClick={open}>
+        Add Team
+      </Button>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/teams/ArchiveTeam.tsx
+++ b/web/src/pages/dashboard/teams/ArchiveTeam.tsx
@@ -1,0 +1,109 @@
+import { useMutation } from '@apollo/client';
+import {
+  ActionIcon,
+  Button,
+  Stack,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { ArchiveIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+
+const ARCHIVE_TEAM = gql(`
+  mutation ArchiveTeam($teamId: String!) {
+    archiveTeam(teamId: $teamId) {
+      name
+    }
+  }
+`);
+
+type ArchiveTeamProps = {
+  isArchived: boolean;
+  teamId: string;
+  teamName: string;
+};
+
+export const ArchiveTeam = ({
+  isArchived,
+  teamId,
+  teamName,
+}: ArchiveTeamProps) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const [archiveTeam, { loading }] = useMutation(ARCHIVE_TEAM);
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const onSubmit = () =>
+    archiveTeam({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully archived ${data.archiveTeam?.name}`,
+          title: 'Success',
+        });
+        close();
+        setInputValue('');
+      },
+      refetchQueries: ['ListTeamsForDropdown', 'ListTeamsForTable'],
+      variables: {
+        teamId,
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title={`Archive ${teamName}`}
+      >
+        <Stack gap='md'>
+          <Text size='sm'>
+            This action is{' '}
+            <Text c='red' fw={500} span>
+              irreversible
+            </Text>
+            . Archiving this team will permanently prevent any further
+            modifications or the addition of new resources.
+          </Text>
+          <TextInput
+            label='Please type in the name of the team to continue'
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder={teamName}
+            value={inputValue}
+          />
+          <Button
+            color='red'
+            disabled={inputValue !== teamName || loading}
+            fullWidth
+            loading={loading}
+            mt='sm'
+            onClick={() => onSubmit()}
+            radius='md'
+          >
+            I understand, archive this team
+          </Button>
+        </Stack>
+      </Modal>
+
+      <Tooltip disabled={isArchived} label='Archive'>
+        <ActionIcon
+          color='red'
+          disabled={isArchived}
+          onClick={open}
+          variant='subtle'
+        >
+          <ArchiveIcon size={14} />
+        </ActionIcon>
+      </Tooltip>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/teams/EditTeam.tsx
+++ b/web/src/pages/dashboard/teams/EditTeam.tsx
@@ -1,0 +1,131 @@
+import { useMutation } from '@apollo/client';
+import {
+  ActionIcon,
+  Button,
+  Flex,
+  Stack,
+  Textarea,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { EditIcon } from 'lucide-react';
+import { zod4Resolver } from 'mantine-form-zod-resolver';
+import { z } from 'zod/v4';
+
+import type { EditTeamMutationVariables } from '@/graphql/types';
+
+import { Modal } from '@/components/modal/Modal';
+import { gql } from '@/graphql';
+
+const EDIT_TEAM = gql(`
+  mutation EditTeam($data: EditTeamInput!) {
+    editTeam(data: $data) {
+      name
+    }
+  }
+`);
+
+const editTeamSchema = z.object({
+  description: z.string().min(1, 'Required'),
+  name: z.string().min(1, 'Required'),
+}) satisfies z.ZodType<Omit<EditTeamMutationVariables['data'], 'teamId'>>;
+
+type EditTeamInputProps = {
+  isArchived: boolean;
+  originalDescription: string;
+  originalName: string;
+  teamId: string;
+};
+
+type EditTeamSchema = z.infer<typeof editTeamSchema>;
+
+export const EditTeam = ({
+  isArchived,
+  originalDescription,
+  originalName,
+  teamId,
+}: EditTeamInputProps) => {
+  const [editTeam, { loading }] = useMutation(EDIT_TEAM);
+
+  const [opened, { close, open }] = useDisclosure(false);
+
+  const editTeamForm = useForm({
+    initialValues: {
+      description: originalDescription,
+      name: originalName,
+    },
+    mode: 'uncontrolled',
+    validate: zod4Resolver(editTeamSchema),
+  });
+
+  const onSubmit = (values: EditTeamSchema) =>
+    editTeam({
+      onCompleted: (data) => {
+        notifications.show({
+          message: `Successfully edited ${data.editTeam?.name}`,
+          title: 'Success',
+        });
+        close();
+      },
+      refetchQueries: ['ListTeamsForDropdown', 'ListTeamsForTable'],
+      variables: {
+        data: {
+          description: values.description,
+          name: values.name,
+          teamId,
+        },
+      },
+    });
+
+  return (
+    <>
+      <Modal
+        disabled={loading}
+        onClose={close}
+        opened={opened}
+        size='lg'
+        title={`Edit ${originalName}`}
+      >
+        <form onSubmit={editTeamForm.onSubmit((values) => onSubmit(values))}>
+          <Stack gap='md'>
+            <TextInput
+              disabled={loading}
+              key={editTeamForm.key('name')}
+              label='Team Name'
+              withAsterisk
+              {...editTeamForm.getInputProps('name')}
+            />
+
+            <Textarea
+              disabled={loading}
+              key={editTeamForm.key('description')}
+              label='Description'
+              withAsterisk
+              {...editTeamForm.getInputProps('description')}
+            />
+          </Stack>
+
+          <Flex align='center' justify='end' mt='xl'>
+            <Button color='blue' loading={loading} radius='md' type='submit'>
+              Submit
+            </Button>
+          </Flex>
+        </form>
+      </Modal>
+
+      <Tooltip disabled={isArchived} label='Edit'>
+        <ActionIcon
+          color='blue'
+          disabled={isArchived}
+          onClick={open}
+          variant='subtle'
+        >
+          <EditIcon size={14} />
+        </ActionIcon>
+      </Tooltip>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/teams/TeamsPage.module.css
+++ b/web/src/pages/dashboard/teams/TeamsPage.module.css
@@ -1,0 +1,45 @@
+.header {
+    @media (min-width: 768px) { 
+        display: flex; 
+        gap: 2rem; 
+        justify-content: space-between; 
+        align-items: center; 
+    }
+}
+
+.searchContainer {
+    width: 100%; 
+
+    @media (min-width: 768px) { 
+        width: 50%; 
+    }
+}
+
+.toolbar {
+    display: flex; 
+    gap: 1rem;
+    margin-top: 0.5rem; 
+    flex-direction: column-reverse; 
+    justify-content: flex-end; 
+    align-items: stretch; 
+    width: 100%;
+    margin-top: 0.5rem;
+
+    @media (min-width: 768px) {
+        gap: 0;
+        margin-left: 0.75rem;
+        margin-top: 0; 
+        flex-direction: row; 
+        align-items: center; 
+        width: auto; 
+    }
+}
+
+.buttonContainer {
+    margin-top: 0.5rem;
+
+    @media (min-width: 768px) { 
+        margin-top: 0;
+        margin-left: 0.75rem;
+    }
+}

--- a/web/src/pages/dashboard/teams/TeamsPage.tsx
+++ b/web/src/pages/dashboard/teams/TeamsPage.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react';
+import { useLoaderData } from 'react-router';
+
+import type { TeamsTableLoader } from '@/features/teams/loaders/teamsLoader';
+
+import { IncludeArchivedSwitch } from '@/components/includeArchivedSwitch/IncludeArchivedSwitch';
+import { SearchParamTextInput } from '@/components/searchParamInput/SearchParamInput';
+
+import { AddTeam } from './AddTeam';
+import styles from './TeamsPage.module.css';
+import { TeamsTable } from './TeamsTable';
+
+export const TeamsPage = () => {
+  const queryRef = useLoaderData() as TeamsTableLoader;
+
+  return (
+    <>
+      <header className={styles.header}>
+        <div className={styles.searchContainer}>
+          <SearchParamTextInput param='teamName' />
+        </div>
+        <div className={styles.toolbar}>
+          <IncludeArchivedSwitch />
+          <div className={styles.buttonContainer}>
+            <AddTeam />
+          </div>
+        </div>
+      </header>
+      <Suspense>
+        <TeamsTable queryRef={queryRef} />
+      </Suspense>
+    </>
+  );
+};

--- a/web/src/pages/dashboard/teams/TeamsTable.module.css
+++ b/web/src/pages/dashboard/teams/TeamsTable.module.css
@@ -1,0 +1,17 @@
+.badge {
+    @mixin hover {
+        cursor: pointer;
+    }
+}
+
+.tableContainer {
+    margin-top: 2rem;
+}
+
+.tableRow {
+    white-space: nowrap;
+    
+    @mixin hover {
+        cursor: pointer;
+    }
+}

--- a/web/src/pages/dashboard/teams/TeamsTable.tsx
+++ b/web/src/pages/dashboard/teams/TeamsTable.tsx
@@ -1,0 +1,89 @@
+import { useReadQuery } from '@apollo/client';
+import { Badge, Card, Flex, Table } from '@mantine/core';
+import dayjs from 'dayjs';
+import { useNavigate } from 'react-router';
+
+import type { TeamsTableLoader } from '@/features/teams/loaders/teamsLoader';
+
+import { NoResults } from '@/components/noResults/NoResults';
+import { paths } from '@/config/paths';
+
+import { ArchiveTeam } from './ArchiveTeam';
+import { EditTeam } from './EditTeam';
+import styles from './TeamsTable.module.css';
+
+type TeamsTableProps = {
+  queryRef: TeamsTableLoader;
+};
+
+export const TeamsTable = ({ queryRef }: TeamsTableProps) => {
+  const { data } = useReadQuery(queryRef);
+
+  const navigate = useNavigate();
+
+  const rows =
+    data.listTeams?.map((team) => (
+      <Table.Tr
+        className={styles.tableRow}
+        key={team.teamId}
+        onClick={() =>
+          navigate(paths.dashboard.team.getPath(team.teamId ?? ''))
+        }
+      >
+        <Table.Td>{team.name}</Table.Td>
+        {/* TODO: Probably make this reusable */}
+        <Table.Td>
+          {team.description && team.description.length > 50
+            ? `${team.description.substring(0, 50)}...`
+            : team.description}
+        </Table.Td>
+        <Table.Td>
+          <Badge
+            className={styles.badge}
+            color={team.isArchived ? 'red' : 'blue'}
+          >
+            {team.isArchived ? 'Archived' : 'Active'}
+          </Badge>
+        </Table.Td>
+        <Table.Td>{dayjs(team.dateModified).format('YYYY-MM-DD')}</Table.Td>
+        <Table.Td onClick={(e) => e.stopPropagation()}>
+          <Flex gap={2}>
+            <EditTeam
+              isArchived={!!team.isArchived}
+              originalDescription={team.description ?? ''}
+              originalName={team.name ?? ''}
+              teamId={team.teamId ?? ''}
+            />
+            <ArchiveTeam
+              isArchived={!!team.isArchived}
+              teamId={team.teamId ?? ''}
+              teamName={team.name ?? ''}
+            />
+          </Flex>
+        </Table.Td>
+      </Table.Tr>
+    )) ?? [];
+
+  return (
+    <div className={styles.tableContainer}>
+      <Card bg='transparent' p={0} withBorder>
+        <Table.ScrollContainer minWidth={500} type='native'>
+          <Table highlightOnHover>
+            <Table.Thead style={{ whiteSpace: 'nowrap' }}>
+              <Table.Tr>
+                <Table.Th>Name</Table.Th>
+                <Table.Th>Description</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Last Modified</Table.Th>
+                <Table.Th className='sr-only' />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.length > 0 ? rows : <NoResults colSpan={5} />}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      </Card>
+    </div>
+  );
+};

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -118,6 +118,26 @@ const createAppRouter = () =>
               },
               path: paths.dashboard.storage.path,
             },
+            {
+              handle: {
+                crumb: () => 'Teams',
+              },
+              lazy: async () => {
+                const { TeamsPage } = await import(
+                  './pages/dashboard/teams/TeamsPage'
+                );
+                return { Component: TeamsPage };
+              },
+              loader: async (params) => {
+                const { teamsTableLoader } = await import(
+                  './features/teams/loaders/teamsLoader'
+                );
+
+                const queryRef = await teamsTableLoader(params);
+                return queryRef;
+              },
+              path: paths.dashboard.teams.path,
+            },
           ],
           id: 'dashboard',
           lazy: async () => {
@@ -127,11 +147,11 @@ const createAppRouter = () =>
             return { Component: DashboardLayout };
           },
           loader: async () => {
-            const { teamsLoader } = await import(
+            const { teamsDropdownLoader } = await import(
               './features/teams/loaders/teamsLoader'
             );
 
-            const queryRef = teamsLoader();
+            const queryRef = teamsDropdownLoader();
             return queryRef;
           },
         },


### PR DESCRIPTION
- Added teams page that performs crud operations related to teams
- Exposed the team's description and archived flags in the teams graphql schema
- Added explicit error handling on backend for attempted mutations against archived teams
- Added mutations for editing and archiving a team (owner permissions only)
- Added include archive flag and team name as args for list teams query