### PR TITLE
Fix k8s Service Dependency Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *dist
 
 # And permit certain files
+!.dockerignore
 !.gitignore
 !LICENSE
 
@@ -30,6 +31,7 @@
 !*.svg
 !*.html
 !*.md
+!*.sh
 !*.sql
 !*.graphql
 !.prettierrc

--- a/apollo/.dockerignore
+++ b/apollo/.dockerignore
@@ -1,0 +1,7 @@
+.husky
+dist
+node_modules
+.lintstagedrc
+.prettier*
+eslint.config.mjs
+README.md

--- a/apollo/Dockerfile
+++ b/apollo/Dockerfile
@@ -1,15 +1,22 @@
-# pull official base image
-FROM node:lts
+FROM node:20-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
 WORKDIR /app
 
-RUN apt-get update
-RUN npm install -g pnpm
+FROM base AS deps
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
-# Files required by pnpm install
-# pnpm fetch does require only lockfile
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
+FROM base
+COPY --from=deps /app/node_modules /app/node_modules
+COPY . /app
 
-ADD . ./
-RUN pnpm install -r
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["pnpm", "start"]

--- a/apollo/apollo.k8s.yml
+++ b/apollo/apollo.k8s.yml
@@ -32,12 +32,11 @@ spec:
       containers:
         - name: dstk-apollo
           image: dstk-apollo
-          # env:
-          # - name: STORAGE_PROVIDER_KEY
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: storage-provider-key
-          #       key: enc-key
+          env:
+            - name: DATABASE_URL
+              value: postgresql://postgres:postgres@dstk-postgres:5432/postgres
+          ports:
+            - containerPort: 4000
 
 ---
 apiVersion: v1

--- a/apollo/entrypoint.sh
+++ b/apollo/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Convenience functions
+info () {
+  printf "\r[ \033[00;34m..\033[0m ] $1\n"
+}
+
+success () {
+  printf "\r\033[2K[ \033[00;32mOK\033[0m ] $1\n"
+}
+
+fail () {
+  printf "\r\033[2K[\033[0;31mFAIL\033[0m] $1\n"
+}
+
+info "Waiting for PostgreSQL database..."
+until pg_isready -h dstk-postgres -p 5432 -U postgres > /dev/null 2>&1; do
+  info "PostgreSQL not ready, retrying..."
+  sleep 2
+done
+
+success "PostgreSQL is ready!"
+info "Starting Apollo server..."
+exec "$@"

--- a/apollo/package.json
+++ b/apollo/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "compile": "tsc",
-    "schemagen": "kysely-codegen --dialect postgres --env-file .env --out-file ./src/db/db.d.ts",
+    "schemagen": "kysely-codegen --dialect postgres --out-file ./src/db/db.d.ts",
     "start": "pnpm run schemagen && pnpm run compile && node ./dist/index.js",
     "dev": "NODE_ENV=dev && pnpm run start",
     "lint": "eslint 'src/**/*.ts' --config ./eslint.config.mjs",

--- a/postgres/postgres.k8s.yml
+++ b/postgres/postgres.k8s.yml
@@ -21,6 +21,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: dstk-postgres
       io.kompose.service: dstk-postgres
   strategy:
     type: Recreate
@@ -44,6 +45,8 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: postgres-password
+          ports:
+            - containerPort: 5432
 
 ---
 apiVersion: v1

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+.prettierrc
+eslint.config.js
+README.md
+dist

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,15 +1,22 @@
-# pull official base image
-FROM node:lts
+FROM node:20-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+RUN apt-get update && apt-get install -y netcat-traditional && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
 WORKDIR /app
 
-RUN apt-get update
-RUN npm install -g pnpm
+FROM base AS deps
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
-# Files required by pnpm install
-# pnpm fetch does require only lockfile
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
+FROM base
+COPY --from=deps /app/node_modules /app/node_modules
+COPY . /app
 
-ADD . ./
-RUN pnpm install -r
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["pnpm", "dev"]

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Convenience functions
+info () {
+  printf "\r[ \033[00;34m..\033[0m ] $1\n"
+}
+
+success () {
+  printf "\r\033[2K[ \033[00;32mOK\033[0m ] $1\n"
+}
+
+fail () {
+  printf "\r\033[2K[\033[0;31mFAIL\033[0m] $1\n"
+}
+
+info "Waiting for Apollo GraphQL service..."
+until nc -z dstk-apollo 4000; do
+  info "Apollo not ready, retrying..."
+  sleep 2
+done
+
+success "Apollo is ready!"
+info "Starting development server..."
+exec "$@"

--- a/web/web.k8s.yml
+++ b/web/web.k8s.yml
@@ -21,6 +21,11 @@ spec:
       containers:
         - name: dstk-web
           image: dstk-web
+          env:
+          - name: VITE_APP_API_URL
+            value: http://dstk-apollo:4000/graphql
+          ports:
+            - containerPort: 5173
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Hola! Sorry for the delay. Turns out tiny humans require much attention. Also, just needed a break from tippy-typing for a bit.

## Overview
Fixes k8s deployments for local development where services were failing to connect to dependencies during startup. Also optimized (modernized? idk) Dockerfiles for the web and apollo service based on the docker example from the [pnpm docs](https://pnpm.io/docker#example-1-build-a-bundle-in-a-docker-container).

## Problem
When bootstrapping the development environment, services would fail on startup because:
- Web's codegen tried to connect to Apollo before the service was ready
- Apollo's schemagen tried to connect to postgres before the database was ready
- .env files were referencing `localhost` instead of K8s service DNS names

## Changes

### Docker Stuff
- **Multi-stage builds**: Separate build stages for dependencies and compilation for the web and apollo services + .dockerignore files were created
- **Entrypoint scripts**: Handle service readiness checks before starting applications
  - Apollo waits for postgres
  - Web waits for Apollo
    - Side note: experimented with [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) but apparently this is against best practices (supposedly services should handle retry logic internally).

### Kubernetes Stuff
- Use K8s environment variables instead of `.env` files
- Added port mappings in each config. Not sure if this is needed since we define it in the `skaffold.yml` file. Yell at me if redundant
- Added missing `app.kubernetes.io/name:` in the postgres k8's file

