### PR TITLE
Fix Apollo Schemagen

### DIFF
--- a/apollo/apollo.k8s.yml
+++ b/apollo/apollo.k8s.yml
@@ -34,7 +34,7 @@ spec:
           image: dstk-apollo
           env:
             - name: DATABASE_URL
-              value: postgresql://postgres:postgres@dstk-postgres:5432/postgres
+              value: postgresql://postgres:postgres@dstk-postgres:5432/dstk
             - name: SMTP_HOST
               value: dstk-smtp
             - name: SMTP_PORT

--- a/apollo/src/db/kysely.ts
+++ b/apollo/src/db/kysely.ts
@@ -4,12 +4,13 @@ import dotenv from "dotenv";
 import { Kysely, PostgresDialect } from "kysely";
 // https://github.com/brianc/node-postgres/issues/2819
 import pg from "pg";
+import { env } from "../config/env.js";
 
 dotenv.config();
 const { Pool } = pg;
 
 export const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: env.DATABASE_URL,
   max: 10,
 });
 


### PR DESCRIPTION
Hahahahahahahahahahahahaha.

This is the wrong database: `postgresql://postgres:postgres@dstk-postgres:5432/postgres`

Validated that Apollo actually starts now (I chalked previous errors to me not running `storage upgrade`. Turns out I'm just a silly goose):

```bash
[dstk-apollo] > @ start /app
[dstk-apollo] > pnpm run schemagen && pnpm run compile && node ./dist/index.js
[dstk-apollo]
[dstk-apollo]
[dstk-apollo] > @ schemagen /app
[dstk-apollo] > kysely-codegen --dialect postgres --out-file ./src/db/db.d.ts
[dstk-apollo]
[dstk-apollo] • Using dialect 'postgres'.
[dstk-apollo] • Introspecting database...
[dstk-apollo] ✓ Introspected 13 tables and generated ./src/db/db.d.ts in 17ms.
[dstk-apollo]
[dstk-apollo]
[dstk-apollo] > @ compile /app
[dstk-apollo] > tsc
[dstk-apollo]
[ .. ] Apollo not ready, retrying...
[dstk-apollo] 🚀 Server ready at http://localhost:4000/graphql
```