### PR TITLE
Implement Google OAuth Flows

### DIFF
--- a/apollo/apollo.k8s.yml
+++ b/apollo/apollo.k8s.yml
@@ -1,12 +1,17 @@
+# 🚨 This is a placeholder for the secret that needs to be created manually
+# Idk how you actually commit secrets stuff with k8s configs cause I'm a pleb
+# TODO: Probably throw actual important things into a secrets manager
+
 # apiVersion: v1
 # kind: Secret
 # metadata:
-#   name: storage-provider-key
+#   name: apollo-secret
 #   labels:
 #     io.kompose.service: dstk-apollo
 #     app.kubernetes.io/name: dstk-apollo
 # data:
-#   enc-key: SW1JbkRhbmdlcgo=
+#   google-client-id:
+#   google-client-secret:
 
 ---
 apiVersion: apps/v1
@@ -35,6 +40,16 @@ spec:
           env:
             - name: DATABASE_URL
               value: postgresql://postgres:postgres@dstk-postgres:5432/dstk
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: google-client-id
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: google-client-secret
             - name: SMTP_HOST
               value: dstk-smtp
             - name: SMTP_PORT

--- a/apollo/src/config/env.ts
+++ b/apollo/src/config/env.ts
@@ -5,6 +5,8 @@ config();
 
 const envVariables = z.object({
   DATABASE_URL: z.string(),
+  GOOGLE_CLIENT_ID: z.string(),
+  GOOGLE_CLIENT_SECRET: z.string(),
   SMTP_HOST: z.string(),
   SMTP_PORT: z.coerce.number(),
 });

--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -2,7 +2,6 @@ import { builder } from "../../builder.js";
 import { db } from "../../db/kysely.js";
 import { auth } from "../../utils/auth.js";
 import { AccountError } from "../../utils/errors.js";
-import { createTeam } from "../../utils/teamUtils.js";
 import { User } from "../user/user.js";
 
 export const AccountInputType = builder.inputType("AccountInput", {
@@ -73,12 +72,6 @@ builder.mutationFields(t => ({
         .where("dstk_user.user.id", "=", response.user.id)
         .executeTakeFirstOrThrow();
 
-      await createTeam({
-        description: `${user.user_name}'s private team. Automatically created by DSTK.`,
-        name: "Personal Team",
-        userId: user.user_id,
-      });
-
       return user;
     },
   }),
@@ -112,6 +105,32 @@ builder.mutationFields(t => ({
       ctx.res.set("Set-Cookie", cookies);
 
       return response.token;
+    },
+  }),
+  generateGoogleOAuthUrl: t.field({
+    type: "String",
+    authScopes: {
+      anonymousRequest: true,
+    },
+    args: {
+      callbackURL: t.arg.string({ required: true }),
+    },
+    async resolve(_args, args, ctx) {
+      const { response, headers } = await auth.api.signInSocial({
+        body: {
+          provider: "google",
+          callbackURL: args.callbackURL,
+        },
+        headers: ctx.headers,
+        returnHeaders: true,
+      });
+
+      const cookies = headers.get("set-cookie");
+      if (cookies) {
+        ctx.res.set("Set-Cookie", cookies);
+      }
+
+      return response.url;
     },
   }),
   logout: t.field({

--- a/apollo/src/index.ts
+++ b/apollo/src/index.ts
@@ -3,7 +3,7 @@ import { ApolloServer } from "@apollo/server";
 import { expressMiddleware } from "@apollo/server/express4";
 import { ApolloServerPluginDrainHttpServer } from "@apollo/server/plugin/drainHttpServer";
 import { ApolloServerPluginLandingPageLocalDefault } from "@apollo/server/plugin/landingPage/default";
-import { fromNodeHeaders } from "better-auth/node";
+import { fromNodeHeaders, toNodeHandler } from "better-auth/node";
 import cookieparser from "cookie-parser";
 import cors from "cors";
 import express from "express";
@@ -25,6 +25,16 @@ const server = new ApolloServer({
 });
 
 await server.start();
+
+// Use better-auth rest API endpoints for OAuth callbacks
+app.use(
+  "/api/auth/callback/*",
+  cors({
+    origin: ["http://localhost:5173", "http://127.0.0.1:5173"],
+    credentials: true,
+  }),
+);
+app.all("/api/auth/callback/*", toNodeHandler(auth));
 
 app.use(
   "/graphql",

--- a/apollo/src/utils/auth.ts
+++ b/apollo/src/utils/auth.ts
@@ -1,9 +1,27 @@
 import { betterAuth } from "better-auth";
+import { env } from "../config/env.js";
 import { pool } from "../db/kysely.js";
 import { transporter } from "./smtp.js";
+import { createTeam } from "./teamUtils.js";
 
 export const auth = betterAuth({
+  /* 🚨 NOTE 🚨
+     You must set the baseURL when using oauth providers to
+     avoid `redirect_uri_mismatch` errors.
+  */
+  baseURL: "http://localhost:4000",
   database: pool,
+  socialProviders: {
+    google: {
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
+      mapProfileToUser: (profile) => {
+        return {
+          user_name: profile.email.split("@")[0],
+        };
+      },
+    },
+  },
   emailAndPassword: {
     enabled: true,
   },
@@ -77,6 +95,23 @@ export const auth = betterAuth({
     defaultCookieAttributes: {
       sameSite: process.env.NODE_ENV === "dev" ? "none" : "Lax",
       secure: true,
+    },
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        after: async (user) => {
+          await createTeam({
+            description: `${user.user_name}'s private team. Automatically created by DSTK.`,
+            name: "Personal Team",
+            /* According to docs: https://www.better-auth.com/docs/concepts/database#database-hooks
+                Additional fields are supported, however full type inference for these fields isn't yet supported.
+                Improved type support is planned
+            */
+            userId: user.user_id as string,
+          });
+        },
+      },
     },
   },
 });

--- a/web/src/features/auth/hooks/oauthHooks.ts
+++ b/web/src/features/auth/hooks/oauthHooks.ts
@@ -1,0 +1,47 @@
+import type { DocumentNode } from "@apollo/client";
+import { useMutation } from "@apollo/client";
+import { useState } from "react";
+import { paths } from "@/config/paths";
+import { gql } from "@/graphql";
+
+export const GENERATE_GOOGLE_OAUTH_URL = gql(`
+    mutation GenerateGoogleOAuthUrl($callbackURL: String!) {
+        generateGoogleOAuthUrl(callbackURL: $callbackURL)
+    }
+`);
+
+type UseOAuthRedirectOptions = {
+  mutation: DocumentNode;
+};
+
+export function useOAuthRedirect({
+  mutation,
+}: UseOAuthRedirectOptions) {
+  const [executeMutation, { loading: mutationLoading }]
+    = useMutation<string>(mutation);
+
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  const loading = mutationLoading || isRedirecting;
+
+  const redirect = async () => {
+    await executeMutation({
+      variables: {
+        callbackURL: `${window.location.origin}${paths.dashboard.overview}`,
+      },
+      onCompleted: (data) => {
+        const url = Object.values(data)[0];
+        setIsRedirecting(true);
+        window.location.href = url;
+      },
+    });
+  };
+
+  return { redirect, loading };
+}
+
+export function useGoogleOAuth() {
+  return useOAuthRedirect({
+    mutation: GENERATE_GOOGLE_OAUTH_URL,
+  });
+}

--- a/web/src/pages/auth/login/LoginForm.module.css
+++ b/web/src/pages/auth/login/LoginForm.module.css
@@ -1,0 +1,9 @@
+.oauthButtonWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+
+  @media (min-width: 640px) {
+    flex-direction: row;
+  }
+}

--- a/web/src/pages/auth/login/LoginForm.tsx
+++ b/web/src/pages/auth/login/LoginForm.tsx
@@ -1,0 +1,129 @@
+import type { LoginInput } from "@/graphql/types";
+import { useMutation } from "@apollo/client";
+import {
+  Button,
+  Checkbox,
+  Divider,
+  Group,
+  PasswordInput,
+  TextInput,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { zod4Resolver } from "mantine-form-zod-resolver";
+import { useNavigate } from "react-router";
+import { z } from "zod/v4";
+import { Anchor } from "@/components/anchor/Anchor";
+import { GithubIcon } from "@/components/icons/github/GitHubIcon";
+import { GoogleIcon } from "@/components/icons/google/GoogleIcon";
+import { paths } from "@/config/paths";
+import { useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
+import { GET_USER } from "@/features/auth/loaders/authLoader";
+import { LIST_TEAMS_FOR_DROPDOWN } from "@/features/teams/loaders/teamsLoader";
+import { gql } from "@/graphql";
+import styles from "./LoginPage.module.css";
+
+const LOGIN = gql(`
+    mutation Login($data: LoginInput!) {
+        login(data: $data)
+    }
+`);
+
+const loginSchema = z.object({
+  email: z
+    .email({
+      error: "Please enter a valid email",
+    })
+    .min(1, "Required"),
+  password: z.string().min(1, "Required"),
+  rememberMe: z.boolean({ message: "Required" }),
+}) satisfies z.ZodType<LoginInput>;
+
+type LoginSchema = z.infer<typeof loginSchema>;
+
+export function LoginForm() {
+  const [login, { loading: loginLoading }] = useMutation(LOGIN);
+
+  const { redirect: loginWithGoogle, loading: googleLoading } = useGoogleOAuth();
+
+  const loading = loginLoading || googleLoading;
+  const navigate = useNavigate();
+
+  const loginForm = useForm({
+    initialValues: {
+      email: "",
+      password: "",
+      rememberMe: false,
+    },
+    mode: "uncontrolled",
+    validate: zod4Resolver(loginSchema),
+  });
+
+  const onSubmit = (values: LoginSchema) =>
+    login({
+      refetchQueries: [{ query: GET_USER }, { query: LIST_TEAMS_FOR_DROPDOWN }],
+      variables: {
+        data: { ...values },
+      },
+      onCompleted: () => navigate(paths.dashboard.overview.path),
+    });
+
+  return (
+    <>
+      <div className={styles.oauthButtonWrapper}>
+        <Button
+          disabled={loading}
+          onClick={loginWithGoogle}
+          fullWidth
+          leftSection={<GoogleIcon height={16} width={17} />}
+          variant="default"
+        >
+          Sign in with Google
+        </Button>
+        <Button
+          disabled={loading}
+          fullWidth
+          leftSection={<GithubIcon height={16} width={17} />}
+          variant="default"
+        >
+          Sign in with Github
+        </Button>
+      </div>
+
+      <Divider label="OR" labelPosition="center" />
+
+      <form onSubmit={loginForm.onSubmit(values => onSubmit(values))}>
+        <TextInput
+          disabled={loading}
+          key={loginForm.key("email")}
+          label="Email"
+          placeholder="you@dstk.org"
+          withAsterisk
+          {...loginForm.getInputProps("email")}
+        />
+        <PasswordInput
+          disabled={loading}
+          key={loginForm.key("password")}
+          label="Password"
+          mt="md"
+          placeholder="Shhhhhhh"
+          withAsterisk
+          {...loginForm.getInputProps("password")}
+        />
+        <Group justify="space-between" mt="lg">
+          <Checkbox
+            disabled={loading}
+            key={loginForm.key("rememberMe")}
+            label="Remember me"
+            {...loginForm.getInputProps("rememberMe", { type: "checkbox" })}
+          />
+          <Anchor component="button" disabled={loading} size="sm">
+            Forgot password?
+          </Anchor>
+        </Group>
+        <Button fullWidth loading={loading} mt="xl" type="submit">
+          Sign in
+        </Button>
+      </form>
+    </>
+  );
+}

--- a/web/src/pages/auth/login/LoginPage.tsx
+++ b/web/src/pages/auth/login/LoginPage.tsx
@@ -12,17 +12,14 @@ import {
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { zod4Resolver } from "mantine-form-zod-resolver";
-
-import { useState } from "react";
-
 import { useNavigate } from "react-router";
 import { z } from "zod/v4";
 import { Anchor } from "@/components/anchor/Anchor";
-import { GithubIcon } from "@/components/icons/github/GithubIcon";
+import { GithubIcon } from "@/components/icons/github/GitHubIcon";
 import { GoogleIcon } from "@/components/icons/google/GoogleIcon";
 import { paths } from "@/config/paths";
+import { useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
 import { GET_USER } from "@/features/auth/loaders/authLoader";
-
 import { LIST_TEAMS_FOR_DROPDOWN } from "@/features/teams/loaders/teamsLoader";
 import { gql } from "@/graphql";
 import styles from "./LoginPage.module.css";
@@ -30,12 +27,6 @@ import styles from "./LoginPage.module.css";
 const LOGIN = gql(`
     mutation Login($data: LoginInput!) {
         login(data: $data)
-    }
-`);
-
-const GENERATE_GOOGLE_OAUTH_URL = gql(`
-    mutation GenerateGoogleOAuthUrl($callbackURL: String!) {
-        generateGoogleOAuthUrl(callbackURL: $callbackURL)
     }
 `);
 
@@ -53,20 +44,10 @@ type LoginSchema = z.infer<typeof loginSchema>;
 
 export function LoginPage() {
   const [login, { loading: loginLoading }] = useMutation(LOGIN);
-  const [generateGoogleOAuthUrl, { loading: generateGoogleOAuthUrlLoading }] = useMutation(GENERATE_GOOGLE_OAUTH_URL);
 
-  /* The GraphQL mutation completes and returns `loading: false` as soon as the
-     OAuth URL is received, but `window.location.href` takes additional time to
-     actually navigate away. This creates a UX gap where buttons re-enable and
-     loading indicators disappear even though the redirect is still happening.
+  const { redirect: loginWithGoogle, loading: googleLoading } = useGoogleOAuth();
 
-     Therefore, we track the state locally to maintain loading indicators and
-     disabled states until the browser navigation completes.
-   */
-  const [isRedirecting, setIsRedirecting] = useState(false);
-
-  const loading = loginLoading || generateGoogleOAuthUrlLoading || isRedirecting;
-
+  const loading = loginLoading || googleLoading;
   const navigate = useNavigate();
 
   const loginForm = useForm({
@@ -88,21 +69,6 @@ export function LoginPage() {
       onCompleted: () => navigate(paths.dashboard.overview.path),
     });
 
-  const handleGoogleSignin = async () => {
-    await generateGoogleOAuthUrl({
-      variables: {
-        callbackURL: `${window.location.origin}${paths.dashboard.overview.path}`,
-      },
-      onCompleted: (data) => {
-        const url = data.generateGoogleOAuthUrl;
-        if (url) {
-          setIsRedirecting(true);
-          window.location.href = url;
-        }
-      },
-    });
-  };
-
   return (
     <div className={styles.main}>
       <div className={styles.titleWrapper}>
@@ -115,7 +81,7 @@ export function LoginPage() {
       <div className={styles.oauthButtonWrapper}>
         <Button
           disabled={loading}
-          onClick={handleGoogleSignin}
+          onClick={loginWithGoogle}
           fullWidth
           leftSection={<GoogleIcon height={16} width={17} />}
           variant="default"

--- a/web/src/pages/auth/login/LoginPage.tsx
+++ b/web/src/pages/auth/login/LoginPage.tsx
@@ -13,22 +13,29 @@ import {
 import { useForm } from "@mantine/form";
 import { zod4Resolver } from "mantine-form-zod-resolver";
 
-import { useNavigate } from "react-router";
+import { useState } from "react";
 
+import { useNavigate } from "react-router";
 import { z } from "zod/v4";
 import { Anchor } from "@/components/anchor/Anchor";
 import { GithubIcon } from "@/components/icons/github/GithubIcon";
 import { GoogleIcon } from "@/components/icons/google/GoogleIcon";
 import { paths } from "@/config/paths";
 import { GET_USER } from "@/features/auth/loaders/authLoader";
-import { LIST_TEAMS_FOR_DROPDOWN } from "@/features/teams/loaders/teamsLoader";
 
+import { LIST_TEAMS_FOR_DROPDOWN } from "@/features/teams/loaders/teamsLoader";
 import { gql } from "@/graphql";
 import styles from "./LoginPage.module.css";
 
 const LOGIN = gql(`
     mutation Login($data: LoginInput!) {
         login(data: $data)
+    }
+`);
+
+const GENERATE_GOOGLE_OAUTH_URL = gql(`
+    mutation GenerateGoogleOAuthUrl($callbackURL: String!) {
+        generateGoogleOAuthUrl(callbackURL: $callbackURL)
     }
 `);
 
@@ -45,7 +52,21 @@ const loginSchema = z.object({
 type LoginSchema = z.infer<typeof loginSchema>;
 
 export function LoginPage() {
-  const [login, { loading }] = useMutation(LOGIN);
+  const [login, { loading: loginLoading }] = useMutation(LOGIN);
+  const [generateGoogleOAuthUrl, { loading: generateGoogleOAuthUrlLoading }] = useMutation(GENERATE_GOOGLE_OAUTH_URL);
+
+  /* The GraphQL mutation completes and returns `loading: false` as soon as the
+     OAuth URL is received, but `window.location.href` takes additional time to
+     actually navigate away. This creates a UX gap where buttons re-enable and
+     loading indicators disappear even though the redirect is still happening.
+
+     Therefore, we track the state locally to maintain loading indicators and
+     disabled states until the browser navigation completes.
+   */
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  const loading = loginLoading || generateGoogleOAuthUrlLoading || isRedirecting;
+
   const navigate = useNavigate();
 
   const loginForm = useForm({
@@ -67,6 +88,21 @@ export function LoginPage() {
       onCompleted: () => navigate(paths.dashboard.overview.path),
     });
 
+  const handleGoogleSignin = async () => {
+    await generateGoogleOAuthUrl({
+      variables: {
+        callbackURL: `${window.location.origin}${paths.dashboard.overview.path}`,
+      },
+      onCompleted: (data) => {
+        const url = data.generateGoogleOAuthUrl;
+        if (url) {
+          setIsRedirecting(true);
+          window.location.href = url;
+        }
+      },
+    });
+  };
+
   return (
     <div className={styles.main}>
       <div className={styles.titleWrapper}>
@@ -79,6 +115,7 @@ export function LoginPage() {
       <div className={styles.oauthButtonWrapper}>
         <Button
           disabled={loading}
+          onClick={handleGoogleSignin}
           fullWidth
           leftSection={<GoogleIcon height={16} width={17} />}
           variant="default"

--- a/web/src/pages/auth/login/LoginPage.tsx
+++ b/web/src/pages/auth/login/LoginPage.tsx
@@ -1,74 +1,13 @@
-import type { LoginInput } from "@/graphql/types";
-import { useMutation } from "@apollo/client";
 import {
-  Button,
-  Checkbox,
-  Divider,
-  Group,
-  PasswordInput,
   Text,
-  TextInput,
   Title,
 } from "@mantine/core";
-import { useForm } from "@mantine/form";
-import { zod4Resolver } from "mantine-form-zod-resolver";
-import { useNavigate } from "react-router";
-import { z } from "zod/v4";
 import { Anchor } from "@/components/anchor/Anchor";
-import { GithubIcon } from "@/components/icons/github/GitHubIcon";
-import { GoogleIcon } from "@/components/icons/google/GoogleIcon";
 import { paths } from "@/config/paths";
-import { useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
-import { GET_USER } from "@/features/auth/loaders/authLoader";
-import { LIST_TEAMS_FOR_DROPDOWN } from "@/features/teams/loaders/teamsLoader";
-import { gql } from "@/graphql";
+import { LoginForm } from "./LoginForm";
 import styles from "./LoginPage.module.css";
 
-const LOGIN = gql(`
-    mutation Login($data: LoginInput!) {
-        login(data: $data)
-    }
-`);
-
-const loginSchema = z.object({
-  email: z
-    .email({
-      error: "Please enter a valid email",
-    })
-    .min(1, "Required"),
-  password: z.string().min(1, "Required"),
-  rememberMe: z.boolean({ message: "Required" }),
-}) satisfies z.ZodType<LoginInput>;
-
-type LoginSchema = z.infer<typeof loginSchema>;
-
 export function LoginPage() {
-  const [login, { loading: loginLoading }] = useMutation(LOGIN);
-
-  const { redirect: loginWithGoogle, loading: googleLoading } = useGoogleOAuth();
-
-  const loading = loginLoading || googleLoading;
-  const navigate = useNavigate();
-
-  const loginForm = useForm({
-    initialValues: {
-      email: "",
-      password: "",
-      rememberMe: false,
-    },
-    mode: "uncontrolled",
-    validate: zod4Resolver(loginSchema),
-  });
-
-  const onSubmit = (values: LoginSchema) =>
-    login({
-      refetchQueries: [{ query: GET_USER }, { query: LIST_TEAMS_FOR_DROPDOWN }],
-      variables: {
-        data: { ...values },
-      },
-      onCompleted: () => navigate(paths.dashboard.overview.path),
-    });
-
   return (
     <div className={styles.main}>
       <div className={styles.titleWrapper}>
@@ -78,61 +17,7 @@ export function LoginPage() {
         </Text>
       </div>
 
-      <div className={styles.oauthButtonWrapper}>
-        <Button
-          disabled={loading}
-          onClick={loginWithGoogle}
-          fullWidth
-          leftSection={<GoogleIcon height={16} width={17} />}
-          variant="default"
-        >
-          Sign in with Google
-        </Button>
-        <Button
-          disabled={loading}
-          fullWidth
-          leftSection={<GithubIcon height={16} width={17} />}
-          variant="default"
-        >
-          Sign in with Github
-        </Button>
-      </div>
-
-      <Divider label="OR" labelPosition="center" />
-
-      <form onSubmit={loginForm.onSubmit(values => onSubmit(values))}>
-        <TextInput
-          disabled={loading}
-          key={loginForm.key("email")}
-          label="Email"
-          placeholder="you@dstk.org"
-          withAsterisk
-          {...loginForm.getInputProps("email")}
-        />
-        <PasswordInput
-          disabled={loading}
-          key={loginForm.key("password")}
-          label="Password"
-          mt="md"
-          placeholder="Shhhhhhh"
-          withAsterisk
-          {...loginForm.getInputProps("password")}
-        />
-        <Group justify="space-between" mt="lg">
-          <Checkbox
-            disabled={loading}
-            key={loginForm.key("rememberMe")}
-            label="Remember me"
-            {...loginForm.getInputProps("rememberMe", { type: "checkbox" })}
-          />
-          <Anchor component="button" disabled={loading} size="sm">
-            Forgot password?
-          </Anchor>
-        </Group>
-        <Button fullWidth loading={loading} mt="xl" type="submit">
-          Sign in
-        </Button>
-      </form>
+      <LoginForm />
 
       <Text className={styles.signUp}>
         New to DSTK?

--- a/web/src/pages/auth/register/RegisterForm.tsx
+++ b/web/src/pages/auth/register/RegisterForm.tsx
@@ -12,15 +12,13 @@ import {
 import { useForm } from "@mantine/form";
 import { zod4Resolver } from "mantine-form-zod-resolver";
 import { useState } from "react";
-
 import { useNavigate } from "react-router";
-
 import { z } from "zod/v4";
-import { GithubIcon } from "@/components/icons/github/GithubIcon";
+import { GithubIcon } from "@/components/icons/github/GitHubIcon";
 import { GoogleIcon } from "@/components/icons/google/GoogleIcon";
 import { paths } from "@/config/paths";
+import { useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
 import { GET_USER } from "@/features/auth/loaders/authLoader";
-
 import {
   LIST_TEAMS_FOR_DROPDOWN,
   LIST_TEAMS_FOR_TABLE,
@@ -96,8 +94,11 @@ type RegisterSchema = z.infer<typeof registerSchema>;
 
 export function RegisterForm() {
   const navigate = useNavigate();
-  const [register, { loading }] = useMutation(CREATE_ACCOUNT);
+  const [register, { loading: registerLoading }] = useMutation(CREATE_ACCOUNT);
 
+  const { redirect: registerWithGoogle, loading: googleLoading } = useGoogleOAuth();
+
+  const loading = registerLoading || googleLoading;
   const [password, setPassword] = useState("");
 
   const registerForm = useForm({
@@ -143,6 +144,7 @@ export function RegisterForm() {
       <div className={styles.oauthButtonWrapper}>
         <Button
           disabled={loading}
+          onClick={registerWithGoogle}
           fullWidth
           leftSection={<GoogleIcon height={16} width={17} />}
           variant="default"


### PR DESCRIPTION
This PR adds Google OAuth so users can sign in with their Google accounts.

## How it works
1. User clicks the Google sign-in button
2. Frontend calls `generateGoogleOAuthUrl` mutation
3. Server returns the Google OAuth consent screen URL
4. User gets redirected to Google, clicks da buttons
5. Profit

## What changed

**Environment & Config**
- Added `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` env vars
  - 🚨 **Heads up:** Currently using my personal Google OAuth app for testing. We'll need to create a proper Google Cloud project under dstk at some point.
  - 💩 Added a TODO in the Apollo k8s config for these values. They're set up as secrets (base64 encoded), but didn't want to commit my actual creds. We should chat about proper secrets management at some point.

**Backend**
- Added `generateGoogleOAuthUrl` mutation
- Moved automatic personal team creation to [Better Auth's database hooks](https://www.better-auth.com/docs/concepts/database#database-hooks) — which fires whenever a new user is created (as opposed to calling `createTeam` in multiple mutations)
- Exposed Better Auth API endpoints at `/api/auth/callback/*` for OAuth callbacks (only the callback endpoints, nothing else)

**Frontend**
- Created a generic `useOAuth` hook that works for Google, GitHub, etc.
- Integrated the hook into login/register pages for Google buttons
- Refactored login page form into its own `<LoginForm />` component (the original component was getting chunky)