### PR TITLE
Integrate Github OAuth

### DIFF
--- a/apollo/apollo.k8s.yml
+++ b/apollo/apollo.k8s.yml
@@ -12,6 +12,8 @@
 # data:
 #   google-client-id:
 #   google-client-secret:
+#   github-client-id:
+#   github-client-secret:
 
 ---
 apiVersion: apps/v1
@@ -50,6 +52,16 @@ spec:
                 secretKeyRef:
                   name: apollo-secret
                   key: google-client-secret
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: github-client-id
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: github-client-secret
             - name: SMTP_HOST
               value: dstk-smtp
             - name: SMTP_PORT

--- a/apollo/src/config/env.ts
+++ b/apollo/src/config/env.ts
@@ -7,6 +7,8 @@ const envVariables = z.object({
   DATABASE_URL: z.string(),
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
+  GITHUB_CLIENT_ID: z.string(),
+  GITHUB_CLIENT_SECRET: z.string(),
   SMTP_HOST: z.string(),
   SMTP_PORT: z.coerce.number(),
 });

--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -4,6 +4,10 @@ import { auth } from "../../utils/auth.js";
 import { AccountError } from "../../utils/errors.js";
 import { User } from "../user/user.js";
 
+export const OAuthProviderEnum = builder.enumType("OAuthProvider", {
+  values: ["google", "github"] as const,
+});
+
 export const AccountInputType = builder.inputType("AccountInput", {
   fields: t => ({
     userName: t.string({ required: true }),
@@ -107,18 +111,19 @@ builder.mutationFields(t => ({
       return response.token;
     },
   }),
-  generateGoogleOAuthUrl: t.field({
+  generateOAuthUrl: t.field({
     type: "String",
     authScopes: {
       anonymousRequest: true,
     },
     args: {
+      provider: t.arg({ type: OAuthProviderEnum, required: true }),
       callbackURL: t.arg.string({ required: true }),
     },
     async resolve(_args, args, ctx) {
       const { response, headers } = await auth.api.signInSocial({
         body: {
-          provider: "google",
+          provider: args.provider,
           callbackURL: args.callbackURL,
         },
         headers: ctx.headers,
@@ -126,9 +131,10 @@ builder.mutationFields(t => ({
       });
 
       const cookies = headers.get("set-cookie");
-      if (cookies) {
-        ctx.res.set("Set-Cookie", cookies);
+      if (cookies === null) {
+        throw new AccountError({ name: "LOGIN_ERROR" });
       }
+      ctx.res.set("Set-Cookie", cookies);
 
       return response.url;
     },

--- a/apollo/src/index.ts
+++ b/apollo/src/index.ts
@@ -27,13 +27,6 @@ const server = new ApolloServer({
 await server.start();
 
 // Use better-auth rest API endpoints for OAuth callbacks
-app.use(
-  "/api/auth/callback/*",
-  cors({
-    origin: ["http://localhost:5173", "http://127.0.0.1:5173"],
-    credentials: true,
-  }),
-);
 app.all("/api/auth/callback/*", toNodeHandler(auth));
 
 app.use(

--- a/apollo/src/utils/auth.ts
+++ b/apollo/src/utils/auth.ts
@@ -21,6 +21,15 @@ export const auth = betterAuth({
         };
       },
     },
+    github: {
+      clientId: env.GITHUB_CLIENT_ID,
+      clientSecret: env.GITHUB_CLIENT_SECRET,
+      mapProfileToUser: (profile) => {
+        return {
+          user_name: profile.email.split("@")[0],
+        };
+      },
+    },
   },
   emailAndPassword: {
     enabled: true,

--- a/web/src/features/auth/hooks/oauthHooks.ts
+++ b/web/src/features/auth/hooks/oauthHooks.ts
@@ -1,24 +1,24 @@
-import type { DocumentNode } from "@apollo/client";
+import type { GenerateOAuthUrlMutationVariables } from "@/graphql/types";
 import { useMutation } from "@apollo/client";
 import { useState } from "react";
 import { paths } from "@/config/paths";
 import { gql } from "@/graphql";
 
-export const GENERATE_GOOGLE_OAUTH_URL = gql(`
-    mutation GenerateGoogleOAuthUrl($callbackURL: String!) {
-        generateGoogleOAuthUrl(callbackURL: $callbackURL)
+export const GENERATE_OAUTH_URL = gql(`
+    mutation GenerateOAuthUrl($provider: OAuthProvider!, $callbackURL: String!) {
+        generateOAuthUrl(provider: $provider, callbackURL: $callbackURL)
     }
 `);
 
 type UseOAuthRedirectOptions = {
-  mutation: DocumentNode;
+  provider: GenerateOAuthUrlMutationVariables["provider"];
 };
 
 export function useOAuthRedirect({
-  mutation,
+  provider,
 }: UseOAuthRedirectOptions) {
   const [executeMutation, { loading: mutationLoading }]
-    = useMutation<string>(mutation);
+    = useMutation<{ generateOAuthUrl: string }>(GENERATE_OAUTH_URL);
 
   const [isRedirecting, setIsRedirecting] = useState(false);
 
@@ -27,12 +27,12 @@ export function useOAuthRedirect({
   const redirect = async () => {
     await executeMutation({
       variables: {
-        callbackURL: `${window.location.origin}${paths.dashboard.overview}`,
+        provider,
+        callbackURL: `${window.location.origin}${paths.dashboard.overview.path}`,
       },
       onCompleted: (data) => {
-        const url = Object.values(data)[0];
         setIsRedirecting(true);
-        window.location.href = url;
+        window.location.href = data.generateOAuthUrl;
       },
     });
   };
@@ -42,6 +42,12 @@ export function useOAuthRedirect({
 
 export function useGoogleOAuth() {
   return useOAuthRedirect({
-    mutation: GENERATE_GOOGLE_OAUTH_URL,
+    provider: "google",
+  });
+}
+
+export function useGithubOAuth() {
+  return useOAuthRedirect({
+    provider: "github",
   });
 }

--- a/web/src/pages/auth/login/LoginForm.tsx
+++ b/web/src/pages/auth/login/LoginForm.tsx
@@ -16,7 +16,7 @@ import { Anchor } from "@/components/anchor/Anchor";
 import { GithubIcon } from "@/components/icons/github/GitHubIcon";
 import { GoogleIcon } from "@/components/icons/google/GoogleIcon";
 import { paths } from "@/config/paths";
-import { useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
+import { useGithubOAuth, useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
 import { GET_USER } from "@/features/auth/loaders/authLoader";
 import { LIST_TEAMS_FOR_DROPDOWN } from "@/features/teams/loaders/teamsLoader";
 import { gql } from "@/graphql";
@@ -44,8 +44,9 @@ export function LoginForm() {
   const [login, { loading: loginLoading }] = useMutation(LOGIN);
 
   const { redirect: loginWithGoogle, loading: googleLoading } = useGoogleOAuth();
+  const { redirect: loginWithGithub, loading: githubLoading } = useGithubOAuth();
 
-  const loading = loginLoading || googleLoading;
+  const loading = loginLoading || googleLoading || githubLoading;
   const navigate = useNavigate();
 
   const loginForm = useForm({
@@ -81,6 +82,7 @@ export function LoginForm() {
         </Button>
         <Button
           disabled={loading}
+          onClick={loginWithGithub}
           fullWidth
           leftSection={<GithubIcon height={16} width={17} />}
           variant="default"

--- a/web/src/pages/auth/register/RegisterForm.tsx
+++ b/web/src/pages/auth/register/RegisterForm.tsx
@@ -17,7 +17,7 @@ import { z } from "zod/v4";
 import { GithubIcon } from "@/components/icons/github/GitHubIcon";
 import { GoogleIcon } from "@/components/icons/google/GoogleIcon";
 import { paths } from "@/config/paths";
-import { useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
+import { useGithubOAuth, useGoogleOAuth } from "@/features/auth/hooks/oauthHooks";
 import { GET_USER } from "@/features/auth/loaders/authLoader";
 import {
   LIST_TEAMS_FOR_DROPDOWN,
@@ -97,8 +97,9 @@ export function RegisterForm() {
   const [register, { loading: registerLoading }] = useMutation(CREATE_ACCOUNT);
 
   const { redirect: registerWithGoogle, loading: googleLoading } = useGoogleOAuth();
+  const { redirect: registerWithGithub, loading: githubLoading } = useGithubOAuth();
 
-  const loading = registerLoading || googleLoading;
+  const loading = registerLoading || googleLoading || githubLoading;
   const [password, setPassword] = useState("");
 
   const registerForm = useForm({
@@ -153,6 +154,7 @@ export function RegisterForm() {
         </Button>
         <Button
           disabled={loading}
+          onClick={registerWithGithub}
           fullWidth
           leftSection={<GithubIcon height={16} width={17} />}
           variant="default"


### PR DESCRIPTION
So users can sign in with their Github account

## Changes
- Added `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` environment variables to Apollo service
- Refactored `generateGoogleOAuthUrl` into a generic `generateOAuthUrl` function that can work for any OAuth provider
- Removed CORS configuration from `/api/auth/callback/*` routes (not needed since OAuth providers call these directly, not our clients)
- Added GitHub login/register functionality to auth forms