### PR TITLE
Add Port, CORS, Better Auth, and App URL env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # And permit certain files
 !.dockerignore
+!.env.example
 !.gitignore
 !LICENSE
 

--- a/apollo/.env.example
+++ b/apollo/.env.example
@@ -1,0 +1,17 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/dstk
+
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+SMTP_HOST=localhost
+SMTP_PORT=25
+
+BETTER_AUTH_SECRET=
+BETTER_AUTH_URL=http://localhost:4000
+APP_URL=http://localhost:5173
+
+PORT=4000
+CORS_ORIGIN=https://sandbox.embed.apollographql.com,http://localhost:5173,http://127.0.0.1:5173

--- a/apollo/apollo.k8s.yml
+++ b/apollo/apollo.k8s.yml
@@ -66,6 +66,28 @@ spec:
               value: dstk-smtp
             - name: SMTP_PORT
               value: "25"
+            - name: PORT
+              value: "4000"
+            - name: CORS_ORIGIN
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: cors-origin
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: better-auth-secret
+            - name: BETTER_AUTH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: better-auth-url
+            - name: APP_URL
+              valueFrom:
+                secretKeyRef:
+                  name: apollo-secret
+                  key: app-url
           ports:
             - containerPort: 4000
 

--- a/apollo/src/config/env.ts
+++ b/apollo/src/config/env.ts
@@ -11,6 +11,11 @@ const envVariables = z.object({
   GITHUB_CLIENT_SECRET: z.string(),
   SMTP_HOST: z.string(),
   SMTP_PORT: z.coerce.number(),
+  PORT: z.coerce.number().default(4000),
+  CORS_ORIGIN: z.string().default("https://sandbox.embed.apollographql.com,http://localhost:5173,http://127.0.0.1:5173"),
+  BETTER_AUTH_SECRET: z.string(),
+  BETTER_AUTH_URL: z.string().default("http://localhost:4000"),
+  APP_URL: z.string().default("http://localhost:5173"),
 });
 
 export const env = envVariables.parse(process.env);

--- a/apollo/src/db/kysely.ts
+++ b/apollo/src/db/kysely.ts
@@ -1,12 +1,10 @@
 import type { DB } from "./db.js";
-import dotenv from "dotenv";
 
 import { Kysely, PostgresDialect } from "kysely";
 // https://github.com/brianc/node-postgres/issues/2819
 import pg from "pg";
 import { env } from "../config/env.js";
 
-dotenv.config();
 const { Pool } = pg;
 
 export const pool = new Pool({

--- a/apollo/src/index.ts
+++ b/apollo/src/index.ts
@@ -7,10 +7,12 @@ import { fromNodeHeaders, toNodeHandler } from "better-auth/node";
 import cookieparser from "cookie-parser";
 import cors from "cors";
 import express from "express";
+import { env } from "./config/env.js";
 import { schema } from "./graphql/index.js";
 import { auth } from "./utils/auth.js";
 
-const PORT = 4000;
+const PORT = env.PORT;
+const corsOrigins = env.CORS_ORIGIN.split(",").map(o => o.trim());
 
 const app = express();
 const httpServer = http.createServer(app);
@@ -32,11 +34,7 @@ app.all("/api/auth/callback/*", toNodeHandler(auth));
 app.use(
   "/graphql",
   cors<cors.CorsRequest>({
-    origin: [
-      "https://sandbox.embed.apollographql.com",
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-    ],
+    origin: corsOrigins,
     credentials: true,
   }),
   express.json(),
@@ -64,7 +62,7 @@ app.use(
         res,
         session: undefined,
         user: {
-          userId: undefined,
+          id: undefined,
         },
       };
     },
@@ -72,4 +70,5 @@ app.use(
 );
 
 await new Promise<void>(resolve => httpServer.listen({ port: PORT }, resolve));
+// eslint-disable-next-line no-console
 console.log(`🚀 Server ready at http://localhost:${PORT}/graphql`);


### PR DESCRIPTION
### `env.ts`
  - Added `PORT`, `CORS_ORIGIN`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, and `APP_URL` to zod schema

### `index.ts`
  - Port is now read from the env
  - Cors origins are now read from the env
  - Fixed `user: { userId: undefined }` → `user: { id: undefined }` since we got rid of the `user_id` column

### `kysely.ts`
  - Removed `dotenv` import and reads from the env instead

### `apollo.k8s.yml`
  - Added additional env vars

### `.env.example`
  - Self explanatory; not needed but it's nice to have in case you just want to run this outside of k8s.

### `.gitignore`
  - Allow `.env.example` files