### PR TITLE
Add Organizations Support and RBAC; Refactor Auth Flows

### DIFF
--- a/apollo/src/graphql/auth/auth.ts
+++ b/apollo/src/graphql/auth/auth.ts
@@ -20,9 +20,9 @@ builder.objectType(ApiKey, {
       type: User,
       async resolve(root: KyselyApiKey, _args, _ctx) {
         const result = await db
-          .selectFrom("dstk_user.user")
+          .selectFrom("dstk_user.users")
           .selectAll()
-          .where("dstk_user.user.user_id", "=", root.user_id)
+          .where("dstk_user.users.id", "=", root.user_id)
           .executeTakeFirstOrThrow();
 
         return result;

--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -48,7 +48,7 @@ builder.mutationFields(t => ({
         .where(
           ({ fn }) => fn("lower", ["dstk_user.users.user_name"]),
           "=",
-          args.data.userName.toLowerCase(),
+          args.data.userName,
         )
         .executeTakeFirst();
       if (userName) {

--- a/apollo/src/graphql/auth/authMutations.ts
+++ b/apollo/src/graphql/auth/authMutations.ts
@@ -1,6 +1,7 @@
 import { builder } from "../../builder.js";
 import { db } from "../../db/kysely.js";
 import { auth } from "../../utils/auth.js";
+import { handleAuthCookies } from "../../utils/cookie-monster.js";
 import { AccountError } from "../../utils/errors.js";
 import { User } from "../user/user.js";
 
@@ -42,12 +43,12 @@ builder.mutationFields(t => ({
     },
     async resolve(_root, args, ctx) {
       const userName = await db
-        .selectFrom("dstk_user.user")
-        .select("dstk_user.user.user_name")
+        .selectFrom("dstk_user.users")
+        .select("dstk_user.users.user_name")
         .where(
-          ({ fn }) => fn("lower", ["dstk_user.user.user_name"]),
+          ({ fn }) => fn("lower", ["dstk_user.users.user_name"]),
           "=",
-          args.data.userName,
+          args.data.userName.toLowerCase(),
         )
         .executeTakeFirst();
       if (userName) {
@@ -64,16 +65,12 @@ builder.mutationFields(t => ({
         },
       });
 
-      const cookies = headers.get("set-cookie");
-      if (cookies === null) {
-        throw new AccountError({ name: "ACCOUNT_REGISTRATION_ERROR" });
-      }
-      ctx.res.set("Set-Cookie", cookies);
+      await handleAuthCookies({ headers, ctx });
 
       const user = await db
-        .selectFrom("dstk_user.user")
+        .selectFrom("dstk_user.users")
         .selectAll()
-        .where("dstk_user.user.id", "=", response.user.id)
+        .where("dstk_user.users.id", "=", response.user.id)
         .executeTakeFirstOrThrow();
 
       return user;
@@ -87,7 +84,7 @@ builder.mutationFields(t => ({
     args: {
       data: t.arg({ type: LoginInputType, required: true }),
     },
-    async resolve(_args, args, ctx) {
+    async resolve(_root, args, ctx) {
       let body = {
         email: args.data.email,
         password: args.data.password,
@@ -102,11 +99,7 @@ builder.mutationFields(t => ({
         body,
       });
 
-      const cookies = headers.get("set-cookie");
-      if (cookies === null) {
-        throw new AccountError({ name: "LOGIN_ERROR" });
-      }
-      ctx.res.set("Set-Cookie", cookies);
+      await handleAuthCookies({ headers, ctx });
 
       return response.token;
     },
@@ -120,7 +113,7 @@ builder.mutationFields(t => ({
       provider: t.arg({ type: OAuthProviderEnum, required: true }),
       callbackURL: t.arg.string({ required: true }),
     },
-    async resolve(_args, args, ctx) {
+    async resolve(_root, args, ctx) {
       const { response, headers } = await auth.api.signInSocial({
         body: {
           provider: args.provider,
@@ -130,17 +123,16 @@ builder.mutationFields(t => ({
         returnHeaders: true,
       });
 
-      const cookies = headers.get("set-cookie");
-      if (cookies === null) {
-        throw new AccountError({ name: "LOGIN_ERROR" });
-      }
-      ctx.res.set("Set-Cookie", cookies);
+      await handleAuthCookies({ headers, ctx });
 
       return response.url;
     },
   }),
   logout: t.field({
     type: "Boolean",
+    authScopes: {
+      loggedIn: true,
+    },
     async resolve(_root, _args, ctx) {
       const { headers, response } = await auth.api.signOut({
         headers: ctx.headers,
@@ -157,6 +149,9 @@ builder.mutationFields(t => ({
   }),
   sendVerificationEmail: t.field({
     type: "Boolean",
+    authScopes: {
+      loggedIn: true,
+    },
     async resolve(_root, _args, ctx) {
       try {
         await auth.api.sendVerificationEmail({

--- a/apollo/src/utils/auth.ts
+++ b/apollo/src/utils/auth.ts
@@ -1,15 +1,56 @@
 import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+import { createAccessControl } from "better-auth/plugins/access";
+import { defaultStatements, ownerAc } from "better-auth/plugins/organization/access";
 import { env } from "../config/env.js";
 import { pool } from "../db/kysely.js";
 import { transporter } from "./smtp.js";
 import { createTeam } from "./teamUtils.js";
+
+const statement = {
+  ...defaultStatements,
+  // Can't use team as that is an already baked in permission group from better auth
+  dstkTeam: ["archive", "cancelInvite", "edit", "invite"],
+  model: ["archive", "create", "edit"],
+  modelVersion: ["archive", "create", "download", "edit", "publish"],
+  project: ["archive", "create", "edit"],
+  storageProvider: ["archive", "create", "edit"],
+} as const;
+
+const ac = createAccessControl(statement);
+
+const viewer = ac.newRole({
+  dstkTeam: [],
+  model: [],
+  modelVersion: [],
+  project: [],
+  storageProvider: [],
+});
+
+const member = ac.newRole({
+  dstkTeam: [],
+  model: ["archive", "create", "edit"],
+  modelVersion: ["archive", "create", "download", "edit", "publish"],
+  project: ["archive", "create", "edit"],
+  storageProvider: ["create", "edit"],
+});
+
+const owner = ac.newRole({
+  dstkTeam: ["archive", "cancelInvite", "edit", "invite"],
+  model: ["archive", "create", "edit"],
+  modelVersion: ["archive", "create", "download", "edit", "publish"],
+  project: ["archive", "create", "edit"],
+  storageProvider: ["archive", "create", "edit"],
+  ...ownerAc.statements,
+});
 
 export const auth = betterAuth({
   /* 🚨 NOTE 🚨
      You must set the baseURL when using oauth providers to
      avoid `redirect_uri_mismatch` errors.
   */
-  baseURL: "http://localhost:4000",
+  baseURL: env.BETTER_AUTH_URL,
+  secret: env.BETTER_AUTH_SECRET,
   database: pool,
   socialProviders: {
     google: {
@@ -42,13 +83,13 @@ export const auth = betterAuth({
         from: "no-reply@dstk.org",
         to: user.email,
         subject: "DSTK | Email Verification",
-        html: `Click the link to verify your email: http://localhost:5173/auth${url}`,
+        html: `Click the link to verify your email: ${env.APP_URL}/auth${url}`,
       });
     },
   },
   appName: "dstk",
   user: {
-    modelName: "dstk_user.user",
+    modelName: "dstk_user.users",
     fields: {
       name: "real_name",
       emailVerified: "is_email_verified",
@@ -56,10 +97,6 @@ export const auth = betterAuth({
       updatedAt: "date_modified",
     },
     additionalFields: {
-      user_id: {
-        type: "string",
-        required: false,
-      },
       user_name: {
         type: "string",
         required: true,
@@ -100,6 +137,53 @@ export const auth = betterAuth({
       updatedAt: "date_modified",
     },
   },
+  plugins: [
+    organization({
+      ac,
+      roles: {
+        viewer,
+        member,
+        owner,
+      },
+      schema: {
+        organization: {
+          modelName: "dstk_user.teams",
+          fields: {
+            createdAt: "date_created",
+            updatedAt: "date_modified",
+          },
+        },
+        member: {
+          modelName: "dstk_user.members",
+          fields: {
+            organizationId: "team_id",
+            createdAt: "date_created",
+            updatedAt: "date_modified",
+          },
+        },
+        invitation: {
+          modelName: "dstk_user.invitations",
+          fields: {
+            organizationId: "team_id",
+            inviterId: "inviter_id",
+            expiresAt: "expires_at",
+            createdAt: "date_created",
+            updatedAt: "date_modified",
+          },
+        },
+      },
+      async sendInvitationEmail(data) {
+        const inviteLink = `${env.APP_URL}/auth/accept-invitation/${data.id}`;
+        await transporter.sendMail({
+          from: "no-reply@dstk.org",
+          to: data.email,
+          // TODO: Fill this out more properly w/ team name, inviter name, etc.
+          subject: "DSTK | You've been invited to a team",
+          html: `Click the link to accept your invitation: ${inviteLink}`,
+        });
+      },
+    }),
+  ],
   advanced: {
     defaultCookieAttributes: {
       sameSite: process.env.NODE_ENV === "dev" ? "none" : "Lax",
@@ -113,11 +197,7 @@ export const auth = betterAuth({
           await createTeam({
             description: `${user.user_name}'s private team. Automatically created by DSTK.`,
             name: "Personal Team",
-            /* According to docs: https://www.better-auth.com/docs/concepts/database#database-hooks
-                Additional fields are supported, however full type inference for these fields isn't yet supported.
-                Improved type support is planned
-            */
-            userId: user.user_id as string,
+            userId: user.id,
           });
         },
       },

--- a/apollo/src/utils/cookie-monster.ts
+++ b/apollo/src/utils/cookie-monster.ts
@@ -1,0 +1,16 @@
+import type { Context } from "../builder.js";
+import { AccountError } from "./errors.js";
+
+type HandleAuthCookiesArgs = {
+  headers: Headers;
+  ctx: Context;
+};
+
+export async function handleAuthCookies({ headers, ctx }: HandleAuthCookiesArgs): Promise<void> {
+  const cookies = headers.get("set-cookie");
+  if (cookies === null) {
+    throw new AccountError({ name: "FAILED_TO_CREATE_SESSION" });
+  }
+
+  ctx.res.set("Set-Cookie", cookies);
+}

--- a/apollo/src/utils/errors.ts
+++ b/apollo/src/utils/errors.ts
@@ -8,12 +8,16 @@ type RegistryErrorName
     | "PUBLISHED_MODEL_VERSION_ERROR"
     | "MISSING_UPLOAD_ID_ERROR"
     | "MISSING_PART_NUM_ERROR"
+    | "MISSING_FILENAME_ERROR"
     | "MODEL_PERMISSION_ERROR"
     | "MULTIPART_FINALIZATION_ERROR"
     | "ROLE_NOT_FOUND_ERROR"
+    | "PROVIDER_PERMISSION_ERROR"
     | "TEAM_PERMISSION_ERROR"
     | "PROJECT_PERMISSION_ERROR"
-    | "VERSION_PERMISSION_ERROR";
+    | "VERSION_PERMISSION_ERROR"
+    | "MODEL_WRITE_ERROR"
+    | "MODEL_VERSION_WRITE_ERROR";
 
 const RegistryErrorMessages = {
   ARCHIVED_PROJECT_ERROR: "Projects cannot be modified once archived",
@@ -26,18 +30,23 @@ const RegistryErrorMessages = {
   PUBLISHED_MODEL_VERSION_ERROR: "Published model versions cannot be modified",
   MISSING_UPLOAD_ID_ERROR: "An Upload ID must be supplied for this operation",
   MISSING_PART_NUM_ERROR: "A Part Number must be supplied for this operation",
+  MISSING_FILENAME_ERROR: "A filename must be supplied for this operation",
   MODEL_PERMISSION_ERROR:
         "Either this model doesn't exist or you don't have permission to take that action",
   MULTIPART_FINALIZATION_ERROR:
         "Uploaded parts and their ETags must be supplied to finalize a MPU",
   ROLE_NOT_FOUND_ERROR:
         "Either this role doesn't exist or you don't have permission to take that action",
+  PROVIDER_PERMISSION_ERROR:
+        "Either this storage provider doesn't exist or you don't have permission to take that action",
   TEAM_PERMISSION_ERROR:
         "Either this team doesn't exist or you don't have permission to take that action",
   PROJECT_PERMISSION_ERROR:
         "Either this project doesn't exist or you don't have permission to take that action",
   VERSION_PERMISSION_ERROR:
         "Either this model version doesn't exist or you don't have permission to take that action",
+  MODEL_WRITE_ERROR: "Something went wrong and we were not able to save this model",
+  MODEL_VERSION_WRITE_ERROR: "Something went wrong and we were not able to save this model version",
 };
 
 export class RegistryOperationError extends Error {
@@ -56,18 +65,22 @@ type AccountErrorName
     | "USERNAME_IN_USE_ERROR"
     | "LOGIN_ERROR"
     | "DISABLED_ERROR"
+    | "FAILED_TO_CREATE_SESSION"
     | "INVALID_REFRESH_TOKEN"
     | "EMAIL_VERIFICATION_SEND_ERROR"
-    | "EMAIL_VERIFICATION_ERROR";
+    | "EMAIL_VERIFICATION_ERROR"
+    | "INVALID_SESSION_ERROR";
 
 const AccountErrorMessages = {
   ACCOUNT_REGISTRATION_ERROR: "Something went wrong and we were not able to complete this action",
   USERNAME_IN_USE_ERROR: "An account already exists with this username",
   LOGIN_ERROR: "The username or password supplied was incorrect",
   DISABLED_ERROR: "This account has been disabled",
+  FAILED_TO_CREATE_SESSION: "Failed to create a session. Please try again",
   INVALID_REFRESH_TOKEN: "The refresh token provided was invalid. Please log in again",
   EMAIL_VERIFICATION_SEND_ERROR: "Failed to send verification email. Please try again",
   EMAIL_VERIFICATION_ERROR: "Unable to verify email. The verification link may be invalid or expired",
+  INVALID_SESSION_ERROR: "Your session is invalid or has expired. Please log in again",
 };
 
 export class AccountError extends Error {


### PR DESCRIPTION
Auth-related changes, most important being the organizations and RBAC. The rest is cleanup that fell out of the db schema changes.

### `utils/auth.ts`
- Added organizations plugin
- Redefined the team roles from the old db schema
- Added `sendInvitationEmail` hook
- Fixed all the schema mappings in the config file
- Added the `APP_URL` env variable and removed the hardcoded versions of the better auth base url and secret
- Fixed `databaseHooks` for the personal organization creation: `user.user_id as string` to `user.id`

### `utils/cookie-monster.ts`
- This extracts the cookies pattern (get cookie header, throw if null, forward response)

### `utils/errors.ts`
- Added `FAILED_TO_CREATE_SESSION` and `INVALID_SESSION_ERROR` to `AccountError`
- Added `PROVIDER_PERMISSION_ERROR`, `MODEL_WRITE_ERROR`, `MODEL_VERSION_WRITE_ERROR`,
  `MISSING_FILENAME_ERROR` to `RegistryOperationError`

### `graphql/auth/auth.ts`
- Fixed references to new users table

### `graphql/auth/authMutations.ts`
- Refactored cookie operations
- Fixed references to new users table
- Other small things like adding in appropriate auth scopes to the logout function, swapping `_args` and `_root`, etc.