### PR TITLE
Migrate Model Version Resolvers to use Better Auth Permissions

### DIFF
--- a/apollo/src/graphql/model-version/modelVersion.ts
+++ b/apollo/src/graphql/model-version/modelVersion.ts
@@ -42,9 +42,9 @@ builder.objectType(MLModelVersion, {
       type: User,
       async resolve(root: KyselyMLModelVersion, _args, _ctx) {
         const user = await db
-          .selectFrom("dstk_user.user")
+          .selectFrom("dstk_user.users")
           .selectAll()
-          .where("dstk_user.user.user_id", "=", root.created_by_id)
+          .where("dstk_user.users.id", "=", root.created_by_id)
           .executeTakeFirstOrThrow();
 
         return user;

--- a/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -1,7 +1,7 @@
 import { builder } from "../../builder.js";
 import { db } from "../../db/kysely.js";
+import { auth } from "../../utils/auth.js";
 import { RegistryOperationError } from "../../utils/errors.js";
-import { userHasRole } from "../../utils/rls.js";
 import {
   AbortMultipartUpload,
   CreateMultipartUpload,
@@ -86,32 +86,39 @@ builder.mutationFields(t => ({
 
         const project = await trx
           .selectFrom("dstk_user.projects")
-          .select("dstk_user.projects.team_id")
+          .select(["dstk_user.projects.team_id", "dstk_user.projects.project_id"])
           .where("dstk_user.projects.project_id", "=", parentModel.project_id)
           .executeTakeFirstOrThrow(
             () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
           );
 
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: project.team_id,
-          roles: ["owner", "member"],
-        });
-
         if (parentModel.is_archived === true) {
           throw new RegistryOperationError({ name: "ARCHIVED_MODEL_ERROR" });
+        }
+
+        const { success } = await auth.api.hasPermission({
+          headers: ctx.headers,
+          body: {
+            permissions: {
+              modelVersion: ["create"],
+            },
+            organizationId: project.team_id,
+          },
+        });
+
+        if (!success) {
+          throw new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" });
         }
         const lastModelVersion = await trx
           .selectFrom("registry.model_versions")
           .select("registry.model_versions.numeric_version")
           .where("registry.model_versions.model_id", "=", args.data.modelId)
-          .orderBy("registry.model_versions.numeric_version desc")
+          .orderBy("registry.model_versions.numeric_version", "desc")
           .executeTakeFirst();
 
         const incrementedVersion = (lastModelVersion?.numeric_version || 0) + 1;
 
-        // TODO: Will add organizations to path once set up
-        const s3_prefix = `organizations/DEFAULT/teams/${project.team_id}/models/${args.data.modelId}/versions/${incrementedVersion}`;
+        const s3_prefix = `teams/${project.team_id}/projects/${project.project_id}/models/${args.data.modelId}/versions/${incrementedVersion}`;
 
         const mlModelVersion = await trx
           .insertInto("registry.model_versions")
@@ -120,7 +127,7 @@ builder.mutationFields(t => ({
             description: args.data.description,
             numeric_version: incrementedVersion,
             s3_prefix,
-            created_by_id: ctx.user.user_id,
+            created_by_id: ctx.user.id,
           })
           .returningAll()
           .executeTakeFirstOrThrow();
@@ -172,25 +179,36 @@ builder.mutationFields(t => ({
             () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
           );
 
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: project.team_id,
-          roles: ["owner", "member"],
+        const { success } = await auth.api.hasPermission({
+          headers: ctx.headers,
+          body: {
+            permissions: {
+              modelVersion: ["edit"],
+            },
+            organizationId: project.team_id,
+          },
         });
+
+        if (!success) {
+          throw new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" });
+        }
 
         if (mlModelVersion.is_archived === true) {
           throw new RegistryOperationError({ name: "ARCHIVED_MODEL_VERSION_ERROR" });
         }
 
-        // TODO: Add Date Modified and Modified By ID
         const result = await trx
           .updateTable("registry.model_versions")
           .set({
             description: args.data.description,
+            date_modified: new Date(),
+            modified_by_id: ctx.user.id,
           })
           .where("registry.model_versions.model_version_id", "=", args.modelVersionId)
           .returningAll()
-          .executeTakeFirst();
+          .executeTakeFirstOrThrow(
+            () => new RegistryOperationError({ name: "MODEL_VERSION_WRITE_ERROR" }),
+          );
 
         return result;
       });
@@ -239,11 +257,19 @@ builder.mutationFields(t => ({
             () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
           );
 
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: project.team_id,
-          roles: ["owner", "member"],
+        const { success } = await auth.api.hasPermission({
+          headers: ctx.headers,
+          body: {
+            permissions: {
+              modelVersion: ["publish"],
+            },
+            organizationId: project.team_id,
+          },
         });
+
+        if (!success) {
+          throw new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" });
+        }
 
         if (parentModel.is_archived === true) {
           throw new RegistryOperationError({ name: "ARCHIVED_MODEL_ERROR" });
@@ -256,6 +282,8 @@ builder.mutationFields(t => ({
           .updateTable("registry.model_versions")
           .set({
             is_finalized: true,
+            date_modified: new Date(),
+            modified_by_id: ctx.user.id,
           })
           .where("registry.model_versions.model_version_id", "=", args.modelVersionId)
           .returningAll()
@@ -307,16 +335,26 @@ builder.mutationFields(t => ({
             () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
           );
 
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: project.team_id,
-          roles: ["owner", "member"],
+        const { success } = await auth.api.hasPermission({
+          headers: ctx.headers,
+          body: {
+            permissions: {
+              modelVersion: ["archive"],
+            },
+            organizationId: project.team_id,
+          },
         });
+
+        if (!success) {
+          throw new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" });
+        }
 
         const archivedModelVersion = await trx
           .updateTable("registry.model_versions")
           .set({
             is_archived: !mlModelVersion.is_archived,
+            date_modified: new Date(),
+            modified_by_id: ctx.user.id,
           })
           .where("registry.model_versions.model_version_id", "=", args.modelVersionId)
           .returningAll()
@@ -402,11 +440,23 @@ builder.mutationFields(t => ({
 
       // Project viewers are not granted permission to download
       // model objects because I'm feeling petty tonight
-      await userHasRole({
-        userId: ctx.user.user_id,
-        teamId: project.team_id,
-        roles: ["owner", "member"],
+      const { success } = await auth.api.hasPermission({
+        headers: ctx.headers,
+        body: {
+          permissions: {
+            modelVersion: ["download"],
+          },
+          organizationId: project.team_id,
+        },
       });
+
+      if (!success) {
+        throw new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" });
+      }
+
+      if (!args.data.filename) {
+        throw new RegistryOperationError({ name: "MISSING_FILENAME_ERROR" });
+      }
 
       const key = `${mlModelVersion.s3_prefix}/${args.data.filename}`;
 

--- a/apollo/src/graphql/model-version/modelVersionMutations.ts
+++ b/apollo/src/graphql/model-version/modelVersionMutations.ts
@@ -56,7 +56,7 @@ export const PresignedURLInputType = builder.inputType("PresignedURLInput", {
       required: true,
       type: PresignMethod,
     }),
-    filename: t.string(),
+    filename: t.string({ required: true }),
     uploadId: t.string(),
     partNumber: t.int(),
     multipartUpload: t.field({
@@ -452,10 +452,6 @@ builder.mutationFields(t => ({
 
       if (!success) {
         throw new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" });
-      }
-
-      if (!args.data.filename) {
-        throw new RegistryOperationError({ name: "MISSING_FILENAME_ERROR" });
       }
 
       const key = `${mlModelVersion.s3_prefix}/${args.data.filename}`;

--- a/apollo/src/graphql/model-version/modelVersionQueries.ts
+++ b/apollo/src/graphql/model-version/modelVersionQueries.ts
@@ -2,7 +2,6 @@ import { builder } from "../../builder.js";
 import { db } from "../../db/kysely.js";
 import { Encoder } from "../../utils/encoder.js";
 import { RegistryOperationError } from "../../utils/errors.js";
-import { userHasRole } from "../../utils/rls.js";
 import { MLModelVersion } from "./modelVersion.js";
 import { MLModelVersionConnection } from "./modelVersionConnection.js";
 
@@ -26,78 +25,75 @@ builder.queryFields(t => ({
       after: t.arg.string(),
     },
     async resolve(_root, args, ctx) {
-      const result = await db.transaction().execute(async (trx) => {
-        let query = trx.selectFrom("registry.model_versions").selectAll();
+      const parentModel = await db
+        .selectFrom("registry.models")
+        .select("registry.models.project_id")
+        .where("registry.models.model_id", "=", args.modelId)
+        .executeTakeFirstOrThrow(
+          () => new RegistryOperationError({ name: "MODEL_PERMISSION_ERROR" }),
+        );
 
-        if (!args.includeArchived) {
-          query = query.where(
-            "registry.model_versions.is_archived",
-            "is",
-            false,
-          );
-        }
+      const project = await db
+        .selectFrom("dstk_user.projects")
+        .select("dstk_user.projects.team_id")
+        .where("dstk_user.projects.project_id", "=", parentModel.project_id)
+        .executeTakeFirstOrThrow(
+          () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
+        );
 
-        if (args.after) {
-          const [numericVersion] = encoder.decode(args.after);
-          query = query.where(
-            "registry.model_versions.numeric_version",
-            ">",
-            Number.parseInt(numericVersion),
-          );
-        }
+      await db
+        .selectFrom("dstk_user.members")
+        .select("dstk_user.members.id")
+        .where("dstk_user.members.user_id", "=", ctx.user.id)
+        .where("dstk_user.members.team_id", "=", project.team_id)
+        .executeTakeFirstOrThrow(
+          () => new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" }),
+        );
 
-        const parentModel = await trx
-          .selectFrom("registry.models")
-          .select("registry.models.project_id")
-          .where("registry.models.model_id", "=", args.modelId)
-          .executeTakeFirstOrThrow(
-            () => new RegistryOperationError({ name: "MODEL_PERMISSION_ERROR" }),
-          );
+      let query = db
+        .selectFrom("registry.model_versions")
+        .selectAll()
+        .where("registry.model_versions.model_id", "=", args.modelId);
 
-        const project = await trx
-          .selectFrom("dstk_user.projects")
-          .select("dstk_user.projects.team_id")
-          .where("dstk_user.projects.project_id", "=", parentModel.project_id)
-          .executeTakeFirstOrThrow(
-            () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
-          );
+      if (!args.includeArchived) {
+        query = query.where(
+          "registry.model_versions.is_archived",
+          "is",
+          false,
+        );
+      }
 
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: project.team_id,
-          roles: ["owner", "member"],
-        });
+      if (args.after) {
+        const [numericVersion] = encoder.decode(args.after);
+        query = query.where(
+          "registry.model_versions.numeric_version",
+          ">",
+          Number.parseInt(numericVersion),
+        );
+      }
 
-        const mlModelVersions = await query
-          .where("registry.model_versions.model_id", "=", args.modelId)
-          .limit(args.first + 1)
-          .orderBy([
-            "registry.model_versions.id",
-            "registry.model_versions.numeric_version",
-          ])
-          .execute();
+      const mlModelVersions = await query
+        .limit(args.first + 1)
+        .orderBy("registry.model_versions.numeric_version", "asc")
+        .execute();
 
-        const hasPreviousPage = !!args.after;
-        const hasNextPage
-          = mlModelVersions.length > 1 && mlModelVersions.length > args.first;
+      const hasPreviousPage = !!args.after;
+      const hasNextPage = mlModelVersions.length > args.first;
 
-        const lastResult = mlModelVersions[mlModelVersions.length - 2];
-        const continuationToken = hasNextPage ? encoder.encode(lastResult.numeric_version) : undefined;
+      const lastResult = mlModelVersions[mlModelVersions.length - 2];
+      const continuationToken = hasNextPage ? encoder.encode(lastResult.numeric_version) : undefined;
 
-        return {
-          edges: mlModelVersions.slice(0, args.first).map(mlModelVersion => ({
-            cursor: continuationToken,
-            node: mlModelVersion,
-          })),
-          pageInfo: {
-            hasPreviousPage,
-            hasNextPage,
-            continuationToken,
-          },
-        };
-      });
-
-      return result;
+      return {
+        edges: mlModelVersions.slice(0, args.first).map(mlModelVersion => ({
+          cursor: continuationToken,
+          node: mlModelVersion,
+        })),
+        pageInfo: {
+          hasPreviousPage,
+          hasNextPage,
+          continuationToken,
+        },
+      };
     },
   }),
   getMLModelVersion: t.field({
@@ -133,11 +129,14 @@ builder.queryFields(t => ({
           () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
         );
 
-      await userHasRole({
-        userId: ctx.user.user_id,
-        teamId: project.team_id,
-        roles: ["owner", "member", "viewer"],
-      });
+      await db
+        .selectFrom("dstk_user.members")
+        .select("dstk_user.members.id")
+        .where("dstk_user.members.user_id", "=", ctx.user.id)
+        .where("dstk_user.members.team_id", "=", project.team_id)
+        .executeTakeFirstOrThrow(
+          () => new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" }),
+        );
 
       return mlModelVersion;
     },


### PR DESCRIPTION
### `modelVersion.ts`
- Updated `createdBy` field resolver to query `dstk_user.users.id` instead of `dstk_user.user.user_id`

### `modelVersionMutations.ts`
- Replaced `userHasRole` calls with `auth.api.hasPermission` calls
- `createModelVersion`:
  - moved the archived check before the permission check
  - fixed deprecated `orderBy` syntax
  - updated the S3 url to use the team ID
  - swapped `ctx.user.user_id` with `ctx.user.id`
- `editModelVersion`:
  - added `date_modified` and `modified_by_id` to the update call
  - changed `executeTakeFirst` to `executeTakeFirstOrThrow`
- `publishModelVersion`:
  - added `date_modified` and `modified_by_id` to the update call
- `archiveModelVersion`:
  - added `date_modified` and `modified_by_id` to the update call
- `presignURL`:
  - made the `fileName` input arg required since all of the methods use it

### `modelVersionQueries.ts`
- `listMLModelVersions`
  - removed the db transaction
  - moved the membership check before the query builder
  - replaced `userHasRole` with the membership check
  - fixed deprecated `orderBy` syntax
- `getMLModelVersion`
  - replaced `userHasRole` with membership check
  - swapped `executeTakeFirst` with `executeTakeFirstOrThrow`