### PR TITLE
Refactor Storage Provider Resolvers to use Better Auth Permissions; Add Cursor Pagination

### DIFF
--- a/apollo/src/graphql/storage-provider/index.ts
+++ b/apollo/src/graphql/storage-provider/index.ts
@@ -1,4 +1,6 @@
 export * from "./storageProvider.js";
+export * from "./storageProviderConnection.js";
+export * from "./storageProviderEdge.js";
 export * from "./storageProviderMutations.js";
 export * from "./storageProviderObject.js";
 export * from "./storageProviderObjectConnection.js";

--- a/apollo/src/graphql/storage-provider/storageProvider.ts
+++ b/apollo/src/graphql/storage-provider/storageProvider.ts
@@ -33,9 +33,9 @@ builder.objectType(StorageProvider, {
       type: User,
       async resolve(root: KyselyStorageProvider, _args, _ctx) {
         const user = await db
-          .selectFrom("dstk_user.user")
+          .selectFrom("dstk_user.users")
           .selectAll()
-          .where("dstk_user.user.user_id", "=", root.created_by_id)
+          .where("dstk_user.users.id", "=", root.created_by_id)
           .executeTakeFirstOrThrow();
         return user;
       },
@@ -44,9 +44,9 @@ builder.objectType(StorageProvider, {
       type: User,
       async resolve(root: KyselyStorageProvider, _args, _ctx) {
         const user = await db
-          .selectFrom("dstk_user.user")
+          .selectFrom("dstk_user.users")
           .selectAll()
-          .where("dstk_user.user.user_id", "=", root.modified_by_id)
+          .where("dstk_user.users.id", "=", root.modified_by_id)
           .executeTakeFirstOrThrow();
         return user;
       },
@@ -55,9 +55,9 @@ builder.objectType(StorageProvider, {
       type: User,
       async resolve(root: KyselyStorageProvider, _args, _ctx) {
         const user = await db
-          .selectFrom("dstk_user.user")
+          .selectFrom("dstk_user.users")
           .selectAll()
-          .where("dstk_user.user.user_id", "=", root.owner_id)
+          .where("dstk_user.users.id", "=", root.owner_id)
           .executeTakeFirstOrThrow();
         return user;
       },

--- a/apollo/src/graphql/storage-provider/storageProviderConnection.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderConnection.ts
@@ -1,0 +1,29 @@
+import type { PageInfoClass } from "../misc/pageInfo.js";
+import type { StorageProviderEdgeClass } from "./storageProviderEdge.js";
+import { builder } from "../../builder.js";
+import { PageInfo } from "../misc/pageInfo.js";
+import { StorageProviderEdge } from "./storageProviderEdge.js";
+
+export const StorageProviderConnection = builder.objectRef<StorageProviderConnectionClass>("StorageProviderConnection");
+
+builder.objectType(StorageProviderConnection, {
+  fields: t => ({
+    edges: t.field({
+      type: [StorageProviderEdge],
+      resolve(root, _args, _ctx) {
+        return root.edges;
+      },
+    }),
+    pageInfo: t.field({
+      type: PageInfo,
+      resolve(root, _args, _ctx) {
+        return root.pageInfo;
+      },
+    }),
+  }),
+});
+
+export class StorageProviderConnectionClass {
+  edges!: StorageProviderEdgeClass[];
+  pageInfo!: PageInfoClass;
+}

--- a/apollo/src/graphql/storage-provider/storageProviderEdge.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderEdge.ts
@@ -1,0 +1,22 @@
+import type { KyselyStorageProvider } from "./storageProvider.js";
+import { builder } from "../../builder.js";
+import { StorageProvider } from "./storageProvider.js";
+
+export const StorageProviderEdge = builder.objectRef<StorageProviderEdgeClass>("StorageProviderEdge");
+
+builder.objectType(StorageProviderEdge, {
+  fields: t => ({
+    cursor: t.exposeString("cursor", { nullable: true }),
+    node: t.field({
+      type: StorageProvider,
+      async resolve(root, _args, _ctx) {
+        return root.node;
+      },
+    }),
+  }),
+});
+
+export class StorageProviderEdgeClass {
+  cursor?: string;
+  node!: KyselyStorageProvider;
+}

--- a/apollo/src/graphql/storage-provider/storageProviderMutations.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderMutations.ts
@@ -1,8 +1,8 @@
 import { builder } from "../../builder.js";
 import { db } from "../../db/kysely.js";
+import { auth } from "../../utils/auth.js";
 import { Security } from "../../utils/encryption.js";
 import { RegistryOperationError } from "../../utils/errors.js";
-import { userHasRole } from "../../utils/rls.js";
 import { StorageProvider } from "./storageProvider.js";
 
 const EncryptoMatic = new Security();
@@ -37,11 +37,31 @@ builder.mutationFields(t => ({
     },
     async resolve(_root, args, ctx) {
       const results = await db.transaction().execute(async (trx) => {
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: args.data.teamId,
-          roles: ["owner", "member"],
+        const team = await trx
+          .selectFrom("dstk_user.teams")
+          .select("dstk_user.teams.is_archived")
+          .where("dstk_user.teams.id", "=", args.data.teamId)
+          .executeTakeFirstOrThrow(
+            () => new RegistryOperationError({ name: "TEAM_PERMISSION_ERROR" }),
+          );
+
+        if (team.is_archived) {
+          throw new RegistryOperationError({ name: "ARCHIVED_TEAM_ERROR" });
+        }
+
+        const { success } = await auth.api.hasPermission({
+          headers: ctx.headers,
+          body: {
+            permissions: {
+              storageProvider: ["create"],
+            },
+            organizationId: args.data.teamId,
+          },
         });
+
+        if (!success) {
+          throw new RegistryOperationError({ name: "PROVIDER_PERMISSION_ERROR" });
+        }
 
         const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
         const encryptedSecretAccessKey = EncryptoMatic.encrypt(args.data.secretAccessKey);
@@ -54,9 +74,9 @@ builder.mutationFields(t => ({
             bucket: args.data.bucket,
             access_key_id: encryptedAccessKeyId,
             secret_access_key: encryptedSecretAccessKey,
-            created_by_id: ctx.user.user_id,
-            modified_by_id: ctx.user.user_id,
-            owner_id: ctx.user.user_id,
+            created_by_id: ctx.user.id,
+            modified_by_id: ctx.user.id,
+            owner_id: ctx.user.id,
             team_id: args.data.teamId,
           })
           .returningAll()
@@ -86,11 +106,19 @@ builder.mutationFields(t => ({
             () => new RegistryOperationError({ name: "PROVIDER_NOT_FOUND_ERROR" }),
           );
 
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: storageProvider.team_id,
-          roles: ["owner", "member"],
+        const { success } = await auth.api.hasPermission({
+          headers: ctx.headers,
+          body: {
+            permissions: {
+              storageProvider: ["edit"],
+            },
+            organizationId: storageProvider.team_id,
+          },
         });
+
+        if (!success) {
+          throw new RegistryOperationError({ name: "PROVIDER_PERMISSION_ERROR" });
+        }
 
         const encryptedAccessKeyId = EncryptoMatic.encrypt(args.data.accessKeyId);
         const encryptedSecretAccessKey = EncryptoMatic.encrypt(args.data.secretAccessKey);
@@ -101,7 +129,7 @@ builder.mutationFields(t => ({
             access_key_id: encryptedAccessKeyId,
             secret_access_key: encryptedSecretAccessKey,
             date_modified: new Date(),
-            modified_by_id: ctx.user.user_id,
+            modified_by_id: ctx.user.id,
           })
           .where("registry.storage_providers.provider_id", "=", args.data.providerId)
           .returningAll()
@@ -134,11 +162,19 @@ builder.mutationFields(t => ({
             () => new RegistryOperationError({ name: "PROVIDER_NOT_FOUND_ERROR" }),
           );
 
-        await userHasRole({
-          userId: ctx.user.user_id,
-          teamId: storageProvider.team_id,
-          roles: ["owner"],
+        const { success } = await auth.api.hasPermission({
+          headers: ctx.headers,
+          body: {
+            permissions: {
+              storageProvider: ["archive"],
+            },
+            organizationId: storageProvider.team_id,
+          },
         });
+
+        if (!success) {
+          throw new RegistryOperationError({ name: "PROVIDER_PERMISSION_ERROR" });
+        }
 
         const result = await trx
           .updateTable("registry.storage_providers")
@@ -147,7 +183,7 @@ builder.mutationFields(t => ({
             secret_access_key: EncryptoMatic.encrypt("<DELETED>"),
             access_key_id: EncryptoMatic.encrypt("<DELETED>"),
             date_modified: new Date(),
-            modified_by_id: ctx.user.user_id,
+            modified_by_id: ctx.user.id,
           })
           .where("registry.storage_providers.provider_id", "=", args.providerId)
           .returningAll()

--- a/apollo/src/graphql/storage-provider/storageProviderQueries.ts
+++ b/apollo/src/graphql/storage-provider/storageProviderQueries.ts
@@ -1,15 +1,18 @@
 import type { Expression, SqlBool } from "kysely";
 import { builder } from "../../builder.js";
 import { db } from "../../db/kysely.js";
+import { Encoder } from "../../utils/encoder.js";
 import { RegistryOperationError } from "../../utils/errors.js";
-import { userHasRole } from "../../utils/rls.js";
 import { ListObjects } from "../../utils/s3-api.js";
 import { StorageProviderObjectConnection } from "../storage-provider/storageProviderObjectConnection.js";
 import { StorageProvider } from "./storageProvider.js";
+import { StorageProviderConnection } from "./storageProviderConnection.js";
+
+const encoder = new Encoder();
 
 builder.queryFields(t => ({
   listStorageProviders: t.field({
-    type: [StorageProvider],
+    type: StorageProviderConnection,
     authScopes: {
       loggedIn: true,
     },
@@ -17,15 +20,24 @@ builder.queryFields(t => ({
       includeArchived: t.arg.boolean({ required: true, defaultValue: false }),
       bucket: t.arg.string(),
       teamId: t.arg.string({ required: true }),
+      first: t.arg({
+        type: "Limit",
+        defaultValue: 10,
+        required: true,
+      }),
+      after: t.arg.string(),
     },
     async resolve(_root, args, ctx) {
-      await userHasRole({
-        userId: ctx.user.user_id,
-        teamId: args.teamId,
-        roles: ["owner", "member", "viewer"],
-      });
+      await db
+        .selectFrom("dstk_user.members")
+        .select("dstk_user.members.id")
+        .where("dstk_user.members.user_id", "=", ctx.user.id)
+        .where("dstk_user.members.team_id", "=", args.teamId)
+        .executeTakeFirstOrThrow(
+          () => new RegistryOperationError({ name: "PROVIDER_PERMISSION_ERROR" }),
+        );
 
-      const storageProviders = await db
+      let query = db
         .selectFrom("registry.storage_providers")
         .selectAll()
         .where((eb) => {
@@ -54,11 +66,46 @@ builder.queryFields(t => ({
           }
 
           return eb.and(statements);
-        })
-        .orderBy("registry.storage_providers.date_created")
+        });
+
+      if (args.after) {
+        const [id, dateCreated] = encoder.decode(args.after);
+
+        query = query.where(({ eb, and, or }) =>
+          or([
+            eb("registry.storage_providers.date_created", ">", new Date(dateCreated)),
+            and([
+              eb("registry.storage_providers.date_created", "=", new Date(dateCreated)),
+              eb("registry.storage_providers.id", ">", Number.parseInt(id)),
+            ]),
+          ]),
+        );
+      }
+
+      const storageProviders = await query
+        .limit(args.first + 1)
+        .orderBy("registry.storage_providers.date_created", "asc")
+        .orderBy("registry.storage_providers.id", "asc")
         .execute();
 
-      return storageProviders;
+      const hasNextPage = storageProviders.length > args.first;
+
+      const lastResult = storageProviders[storageProviders.length - 2];
+      const continuationToken = hasNextPage
+        ? encoder.encode(lastResult.id.toString(), lastResult.date_created.toISOString())
+        : undefined;
+
+      return {
+        edges: storageProviders.slice(0, args.first).map(storageProvider => ({
+          cursor: continuationToken,
+          node: storageProvider,
+        })),
+        pageInfo: {
+          hasPreviousPage: !!args.after,
+          hasNextPage,
+          continuationToken,
+        },
+      };
     },
   }),
   getStorageProvider: t.field({
@@ -78,11 +125,14 @@ builder.queryFields(t => ({
           () => new RegistryOperationError({ name: "PROVIDER_NOT_FOUND_ERROR" }),
         );
 
-      await userHasRole({
-        userId: ctx.user.user_id,
-        teamId: storageProvider.team_id,
-        roles: ["owner", "member", "viewer"],
-      });
+      await db
+        .selectFrom("dstk_user.members")
+        .select("dstk_user.members.id")
+        .where("dstk_user.members.user_id", "=", ctx.user.id)
+        .where("dstk_user.members.team_id", "=", storageProvider.team_id)
+        .executeTakeFirstOrThrow(
+          () => new RegistryOperationError({ name: "PROVIDER_PERMISSION_ERROR" }),
+        );
 
       return storageProvider;
     },
@@ -128,11 +178,14 @@ builder.queryFields(t => ({
           () => new RegistryOperationError({ name: "PROJECT_PERMISSION_ERROR" }),
         );
 
-      await userHasRole({
-        userId: ctx.user.user_id,
-        teamId: project.team_id,
-        roles: ["owner", "member", "viewer"],
-      });
+      await db
+        .selectFrom("dstk_user.members")
+        .select("dstk_user.members.id")
+        .where("dstk_user.members.user_id", "=", ctx.user.id)
+        .where("dstk_user.members.team_id", "=", project.team_id)
+        .executeTakeFirstOrThrow(
+          () => new RegistryOperationError({ name: "VERSION_PERMISSION_ERROR" }),
+        );
 
       const modelStorageProvider = await db
         .selectFrom("registry.storage_providers")
@@ -149,18 +202,17 @@ builder.queryFields(t => ({
       const prefix = `${modelVersion.s3_prefix}`.concat(args.prefix ? `/${args.prefix}` : "");
 
       /* If no continuation token, the s3 api will always
-               return the root directory as an object. We do not want
-               this returned to the client. */
+         return the root directory as an object. We do not want
+         this returned to the client. */
       const limit = !args.after ? args.first + 1 : args.first;
 
-      // To get Pothos and the S3 API to play nicely
-      const maxKeys = args?.after || undefined;
+      const continuationToken = args.after || undefined;
 
       const { Contents, IsTruncated, NextContinuationToken, Prefix } = await ListObjects(
         modelStorageProvider,
         limit,
         prefix,
-        maxKeys,
+        continuationToken,
       );
 
       const objects = Contents
@@ -174,11 +226,10 @@ builder.queryFields(t => ({
         : [];
 
       return {
-        edges:
-                    objects.map(object => ({
-                      cursor: NextContinuationToken ?? "",
-                      node: object,
-                    })) ?? [],
+        edges: objects.map(object => ({
+          cursor: NextContinuationToken ?? "",
+          node: object,
+        })),
         pageInfo: {
           hasPreviousPage: !!args.after,
           hasNextPage: IsTruncated ?? false,


### PR DESCRIPTION
### `index.ts`
- Added exports for `storageProviderConnection` and `storageProviderEdge`. These are new files that allow us to query the buckets using cursor pagination, making it consistent with the rest of the codebase

### `storageProvider.ts`
- Updated `createdBy`, `modifiedBy`, and `owner` to query `dstk_user.users.id`

### `storageProviderMutations.ts`
- Replaced `userHasRole` calls with `auth.api.hasPermission`
- Replaced all instances of `user.user_id` with `user.id`

### `storageProviderQueries.ts`
- Replaced `userHasRole` calls with membership checks
- `listStorageProviders`: now uses cursor pagination