### PR TITLE
Add Invitation Schema

### DIFF
--- a/apollo/src/graphql/invitation/index.ts
+++ b/apollo/src/graphql/invitation/index.ts
@@ -1,0 +1,3 @@
+export * from "./invitation.js";
+export * from "./invitationConnection.js";
+export * from "./invitationEdge.js";

--- a/apollo/src/graphql/invitation/invitation.ts
+++ b/apollo/src/graphql/invitation/invitation.ts
@@ -2,7 +2,8 @@ import type { Selectable } from "kysely";
 import type { DstkUserInvitations } from "../../db/db.js";
 import { builder } from "../../builder.js";
 import { db } from "../../db/kysely.js";
-import { RegistryOperationError } from "../../utils/errors.js";
+import { Team } from "../team/team.js";
+import { UserRole } from "../team/teamRoles.js";
 import { User } from "../user/user.js";
 
 export type KyselyInvitation = Selectable<DstkUserInvitations>;
@@ -25,13 +26,25 @@ builder.objectType(Invitation, {
           .selectFrom("dstk_user.users")
           .selectAll()
           .where("dstk_user.users.id", "=", root.inviter_id)
-          .executeTakeFirstOrThrow(
-            () => new RegistryOperationError({ name: "TEAM_PERMISSION_ERROR" }),
-          );
+          .executeTakeFirstOrThrow();
       },
     }),
-    teamId: t.exposeString("team_id"),
-    role: t.exposeString("role"),
+    teamId: t.field({
+      type: Team,
+      async resolve(root) {
+        return db
+          .selectFrom("dstk_user.teams")
+          .selectAll()
+          .where("dstk_user.teams.id", "=", root.team_id)
+          .executeTakeFirstOrThrow();
+      },
+    }),
+    role: t.field({
+      type: UserRole,
+      resolve(root) {
+        return root.role;
+      },
+    }),
     status: t.exposeString("status", { nullable: true }),
     expiresAt: t.field({
       type: "String",

--- a/apollo/src/graphql/invitation/invitation.ts
+++ b/apollo/src/graphql/invitation/invitation.ts
@@ -1,0 +1,55 @@
+import type { Selectable } from "kysely";
+import type { DstkUserInvitations } from "../../db/db.js";
+import { builder } from "../../builder.js";
+import { db } from "../../db/kysely.js";
+import { RegistryOperationError } from "../../utils/errors.js";
+import { User } from "../user/user.js";
+
+export type KyselyInvitation = Selectable<DstkUserInvitations>;
+
+export const Invitation = builder.objectRef<KyselyInvitation>("Invitation");
+
+builder.objectType(Invitation, {
+  fields: t => ({
+    id: t.field({
+      type: "ID",
+      resolve(root) {
+        return root.id;
+      },
+    }),
+    email: t.exposeString("email"),
+    inviter: t.field({
+      type: User,
+      async resolve(root) {
+        return db
+          .selectFrom("dstk_user.users")
+          .selectAll()
+          .where("dstk_user.users.id", "=", root.inviter_id)
+          .executeTakeFirstOrThrow(
+            () => new RegistryOperationError({ name: "TEAM_PERMISSION_ERROR" }),
+          );
+      },
+    }),
+    teamId: t.exposeString("team_id"),
+    role: t.exposeString("role"),
+    status: t.exposeString("status", { nullable: true }),
+    expiresAt: t.field({
+      type: "String",
+      resolve(root) {
+        return root.expires_at.toISOString();
+      },
+    }),
+    dateCreated: t.field({
+      type: "String",
+      resolve(root) {
+        return root.date_created.toISOString();
+      },
+    }),
+    dateModified: t.field({
+      type: "String",
+      resolve(root) {
+        return root.date_modified.toISOString();
+      },
+    }),
+  }),
+});

--- a/apollo/src/graphql/invitation/invitationConnection.ts
+++ b/apollo/src/graphql/invitation/invitationConnection.ts
@@ -1,0 +1,29 @@
+import type { PageInfoClass } from "../misc/pageInfo.js";
+import type { InvitationEdgeClass } from "./invitationEdge.js";
+import { builder } from "../../builder.js";
+import { PageInfo } from "../misc/pageInfo.js";
+import { InvitationEdge } from "./invitationEdge.js";
+
+export const InvitationConnection = builder.objectRef<InvitationConnectionClass>("InvitationConnection");
+
+builder.objectType(InvitationConnection, {
+  fields: t => ({
+    edges: t.field({
+      type: [InvitationEdge],
+      resolve(root, _args, _ctx) {
+        return root.edges;
+      },
+    }),
+    pageInfo: t.field({
+      type: PageInfo,
+      resolve(root, _args, _ctx) {
+        return root.pageInfo;
+      },
+    }),
+  }),
+});
+
+export class InvitationConnectionClass {
+  edges!: InvitationEdgeClass[];
+  pageInfo!: PageInfoClass;
+}

--- a/apollo/src/graphql/invitation/invitationEdge.ts
+++ b/apollo/src/graphql/invitation/invitationEdge.ts
@@ -1,0 +1,22 @@
+import type { KyselyInvitation } from "./invitation.js";
+import { builder } from "../../builder.js";
+import { Invitation } from "./invitation.js";
+
+export const InvitationEdge = builder.objectRef<InvitationEdgeClass>("InvitationEdge");
+
+builder.objectType(InvitationEdge, {
+  fields: t => ({
+    cursor: t.exposeString("cursor", { nullable: true }),
+    node: t.field({
+      type: Invitation,
+      async resolve(root, _args, _ctx) {
+        return root.node;
+      },
+    }),
+  }),
+});
+
+export class InvitationEdgeClass {
+  cursor?: string;
+  node!: KyselyInvitation;
+}


### PR DESCRIPTION
Defines the graphql pothos types for the invitation object. No dedicated query or mutation files. This object is used in the auth and team resolvers